### PR TITLE
fix(ci): clear ruff unused imports and eslint errors

### DIFF
--- a/src/stockresearch/agents/master_commentary/debate.py
+++ b/src/stockresearch/agents/master_commentary/debate.py
@@ -7,7 +7,7 @@ import logging
 from collections.abc import AsyncIterator
 from typing import Any
 
-from stockresearch.agents.master_commentary.registry import get_master_config, to_commentary_payload
+from stockresearch.agents.master_commentary.registry import to_commentary_payload
 from stockresearch.agents.master_commentary.schemas import MasterCommentaryOut
 from stockresearch.core.schemas import ModeSettingsOut
 from stockresearch.utils.llm import LLMClient

--- a/src/stockresearch/agents/orchestrator/plan_execute.py
+++ b/src/stockresearch/agents/orchestrator/plan_execute.py
@@ -8,7 +8,6 @@ import json
 import logging
 from typing import Any
 
-from stockresearch.agents.orchestrator.card_merge import merge_plan_cards
 from stockresearch.agents.orchestrator.tools_registry import FINANCE_TOOLS, format_tools_for_prompt
 from stockresearch.i18n.status_events import status_event
 from stockresearch.utils.llm import LLMClient

--- a/src/stockresearch/agents/orchestrator/route_plan.py
+++ b/src/stockresearch/agents/orchestrator/route_plan.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from typing import Literal
 
-from stockresearch.agents.orchestrator.tools_registry import FINANCE_TOOLS
 from stockresearch.agents.orchestrator.complexity import (
     ComplexityResult,
     classify_query,

--- a/src/stockresearch/agents/orchestrator/skills.py
+++ b/src/stockresearch/agents/orchestrator/skills.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any
 

--- a/src/stockresearch/data/providers/market.py
+++ b/src/stockresearch/data/providers/market.py
@@ -11,7 +11,7 @@ import akshare as ak  # type: ignore[import-untyped]
 from stockresearch.core.config import get_settings
 from stockresearch.core.exceptions import DataProviderError
 from stockresearch.data.providers.akshare_quote import fetch_akshare_hist_quotes
-from stockresearch.data.providers.base import run_async_fetch, run_sync_fetch
+from stockresearch.data.providers.base import run_sync_fetch
 from stockresearch.data.providers.efinance_quote import fetch_efinance_kline, fetch_efinance_quotes
 from stockresearch.data.providers.news import _fetch_em_symbol_news_sync
 from stockresearch.data.providers.sina_kline import fetch_sina_kline

--- a/src/stockresearch/services/message_stock.py
+++ b/src/stockresearch/services/message_stock.py
@@ -1,6 +1,5 @@
 """Resolve stock references inside natural-language chat messages."""
 
-import re
 from dataclasses import dataclass
 
 from stockresearch.core.constants import NAME_TO_SYMBOL

--- a/tests/agents/test_complexity.py
+++ b/tests/agents/test_complexity.py
@@ -10,7 +10,6 @@ from stockresearch.agents.orchestrator.complexity import (
     is_trend_explanation_intent,
     resolve_execution_mode,
     should_skip_debate,
-    should_skip_multi_agent,
     wants_deep_research,
 )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ import os
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import text
-from sqlalchemy.orm import sessionmaker
 
 # Force test settings before imports
 os.environ["DATABASE_URL"] = "sqlite://"

--- a/tests/data/test_chips_provider.py
+++ b/tests/data/test_chips_provider.py
@@ -9,7 +9,6 @@ from stockresearch.data.providers.market import ChipsDataProvider
 async def test_chips_provider_returns_defaults_when_offline(monkeypatch: pytest.MonkeyPatch) -> None:
     """AkShare 网络不可用时，ChipsDataProvider 应返回安全默认值，不抛异常。"""
     from stockresearch.data.providers import market as market_mod
-    from stockresearch.data.providers.base import run_sync_fetch
 
     async def fake_run_sync_fetch(*args, **kwargs):  # type: ignore[no-untyped-def]
         return kwargs.get("fallback")

--- a/tests/services/test_chat_context_scope.py
+++ b/tests/services/test_chat_context_scope.py
@@ -3,7 +3,7 @@
 import pytest
 
 from stockresearch.agents.orchestrator.complexity import is_holdings_intent, is_vague_query
-from stockresearch.core.schemas import ChatUserContext, ModeSettingsOut
+from stockresearch.core.schemas import ChatUserContext
 from stockresearch.services.chat_context import should_include_holdings_context
 
 

--- a/web/src/ListsSidebar.tsx
+++ b/web/src/ListsSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import type { HoldingEnriched, WatchlistItem, StockQuoteOut } from "./api";
 import { HoldingTradeInlineRow } from "./HoldingTradeInlineRow";
 import { ListsStockTable } from "./ListsStockTable";
@@ -32,29 +32,35 @@ function sectorColor(sector: string): string {
 
 function SectorDonut({ sectors }: { sectors: SectorWeight[] }) {
   const total = sectors.reduce((a, b) => a + b.pct, 0) || 1;
-  let acc = 0;
   const r = 36;
   const cx = 50;
   const cy = 50;
-  const paths = sectors.map((s) => {
-    const start = (acc / total) * Math.PI * 2 - Math.PI / 2;
-    acc += s.pct;
-    const end = (acc / total) * Math.PI * 2 - Math.PI / 2;
-    const large = end - start > Math.PI ? 1 : 0;
-    const x1 = cx + r * Math.cos(start);
-    const y1 = cy + r * Math.sin(start);
-    const x2 = cx + r * Math.cos(end);
-    const y2 = cy + r * Math.sin(end);
-    return (
-      <path
-        key={s.sector}
-        d={`M ${x1} ${y1} A ${r} ${r} 0 ${large} 1 ${x2} ${y2}`}
-        fill="none"
-        stroke={sectorColor(s.sector)}
-        strokeWidth="10"
-      />
-    );
-  });
+  const paths = sectors.reduce<{ nodes: ReactNode[]; acc: number }>(
+    (state, s) => {
+      const start = (state.acc / total) * Math.PI * 2 - Math.PI / 2;
+      const nextAcc = state.acc + s.pct;
+      const end = (nextAcc / total) * Math.PI * 2 - Math.PI / 2;
+      const large = end - start > Math.PI ? 1 : 0;
+      const x1 = cx + r * Math.cos(start);
+      const y1 = cy + r * Math.sin(start);
+      const x2 = cx + r * Math.cos(end);
+      const y2 = cy + r * Math.sin(end);
+      return {
+        acc: nextAcc,
+        nodes: [
+          ...state.nodes,
+          <path
+            key={s.sector}
+            d={`M ${x1} ${y1} A ${r} ${r} 0 ${large} 1 ${x2} ${y2}`}
+            fill="none"
+            stroke={sectorColor(s.sector)}
+            strokeWidth="10"
+          />,
+        ],
+      };
+    },
+    { nodes: [], acc: 0 },
+  ).nodes;
   return (
     <svg className="lists-donut" viewBox="0 0 100 100" aria-hidden="true">
       {paths}

--- a/web/src/StockChart.tsx
+++ b/web/src/StockChart.tsx
@@ -84,7 +84,6 @@ export function MarketChart({ symbol, compact = false, variant = "stock" }: Mark
 
   const [data, setData] = useState<KlineChart | null>(() => getCachedKline(symbol));
   const dataRef = useRef<KlineChart | null>(data);
-  dataRef.current = data;
   const [loading, setLoading] = useState(() => getCachedKline(symbol) == null);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState("");
@@ -92,6 +91,10 @@ export function MarketChart({ symbol, compact = false, variant = "stock" }: Mark
   const [showRsi, setShowRsi] = useState(false);
   const [selectedMa, setSelectedMa] = useState<number[]>([20]);
   const [maMenuOpen, setMaMenuOpen] = useState(false);
+
+  useEffect(() => {
+    dataRef.current = data;
+  }, [data]);
 
   const allCharts = useCallback((): IChartApi[] => {
     const rt = runtimeRef.current;

--- a/web/src/chartIndicators.ts
+++ b/web/src/chartIndicators.ts
@@ -53,7 +53,7 @@ export function rsiSeries(closes: number[], period = 14): (number | null)[] {
 
   let avgGain = gains.slice(0, period).reduce((a, b) => a + b, 0) / period;
   let avgLoss = losses.slice(0, period).reduce((a, b) => a + b, 0) / period;
-  let idx = period;
+  const idx = period;
   let rs = avgLoss ? avgGain / avgLoss : 100;
   out[idx] = Math.round((100 - 100 / (1 + rs)) * 100) / 100;
 

--- a/web/src/hooks/useCopilotThreads.ts
+++ b/web/src/hooks/useCopilotThreads.ts
@@ -30,8 +30,14 @@ export function useCopilotThreads({ defaultTitle }: UseCopilotThreadsOptions) {
   const [input, setInput] = useState("");
   const threadsRef = useRef(threads);
   const activeIdRef = useRef(activeId);
-  threadsRef.current = threads;
-  activeIdRef.current = activeId;
+
+  useEffect(() => {
+    threadsRef.current = threads;
+  }, [threads]);
+
+  useEffect(() => {
+    activeIdRef.current = activeId;
+  }, [activeId]);
 
   const activeThread = threads.find((t) => t.id === activeId) ?? threads[0];
   const messages = activeThread?.messages ?? [];


### PR DESCRIPTION
## Summary
- Remove 10 unused imports that fail CI `ruff check --select F401`
- Fix 5 eslint errors blocking frontend lint: donut accumulator immutability, prefer-const, and ref updates moved into effects

## Test plan
- [x] `uv run ruff check src tests --select E9,F63,F7,F82,F401`
- [x] `cd web && npx eslint src/` → 0 errors
- [x] `uv run pytest` (350 passed, 3 skipped)
- [x] `cd web && npm run build`
- [ ] Confirm GitHub Actions backend + frontend checks are green


Made with [Cursor](https://cursor.com)