### PR TITLE
fix(ci): remove unused imports in action center tests

### DIFF
--- a/tests/services/test_action_center.py
+++ b/tests/services/test_action_center.py
@@ -9,8 +9,6 @@ import pytest
 from stockresearch.core.schemas import IndexQuoteOut, MarketOverviewOut
 from stockresearch.db.models import Holding, User
 from stockresearch.services.action_center import (
-    _BREADTH_EXTREME_BEAR,
-    _BREADTH_EXTREME_BULL,
     _INDEX_PLUNGE_PCT,
     _INDEX_SURGE_PCT,
     _NORTHBOUND_LARGE_INFLOW,
@@ -18,7 +16,7 @@ from stockresearch.services.action_center import (
     _collect_market_signals,
     generate_daily_actions,
 )
-from stockresearch.services.sentiment import SentimentDriver, SentimentResult
+from stockresearch.services.sentiment import SentimentResult
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Remove unused `_BREADTH_*` and `SentimentDriver` imports that fail `ruff` F401 on `main`

## Test plan
- [x] `ruff check src tests --select E9,F63,F7,F82,F401`
- [ ] CI backend job green on this PR


Made with [Cursor](https://cursor.com)