### PR TITLE
docs: remove screenshot capture howto from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,15 +62,6 @@
 
 ![贵州茅台投研分析](docs/screenshots/moutai-analysis.png)
 
-本地重拍（需 API `:8000` + Web `:5174`）：
-
-```bash
-NODE_PATH=web/node_modules node scripts/capture_screenshots.mjs
-NODE_PATH=web/node_modules node scripts/capture_moutai_analysis.mjs   # 茅台深度分析
-```
-
-输出至 `docs/screenshots/`（focus · market · risk · news · copilot · settings · moutai-analysis）。
-
 ---
 
 <a id="中文"></a>


### PR DESCRIPTION
## Summary
- Remove local recapture command block from homepage README; keep screenshot previews

## Test plan
- [ ] Confirm README on main shows images without capture instructions


Made with [Cursor](https://cursor.com)