### PR TITLE
style(tests): remove unused imports flagged by CI ruff gate

### DIFF
--- a/tests/agents/test_research_stream.py
+++ b/tests/agents/test_research_stream.py
@@ -4,7 +4,6 @@ import pytest
 
 from stockresearch.agents.research.stream import _attach_deep_analysis, run_research_stream
 from stockresearch.core.schemas import (
-    DeepAnalysisOut,
     DimensionResult,
     ImpactOut,
     PricingBridgeOut,

--- a/tests/services/test_daily_bars_factors.py
+++ b/tests/services/test_daily_bars_factors.py
@@ -7,7 +7,7 @@ import pytest
 from stockresearch.db.models import DailyBar
 from stockresearch.services.daily_bars import load_bars, upsert_bars
 from stockresearch.services.factors import compute_numeric_factors
-from stockresearch.services.signal_backtest import _build_sample_bias_note, _factor_tilt
+from stockresearch.services.signal_backtest import _factor_tilt
 
 
 def test_upsert_and_load_daily_bars(db_session) -> None:

--- a/tests/services/test_thesis_build.py
+++ b/tests/services/test_thesis_build.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import re
 
-import pytest
 
 from stockresearch.core.schemas import (
     DeepAnalysisOut,


### PR DESCRIPTION
## Summary
- Remove 3 unused imports in test files flagged by the backend CI ruff gate (`E9,F63,F7,F82,F401`): `tests/agents/test_research_stream.py`, `tests/services/test_daily_bars_factors.py`, `tests/services/test_thesis_build.py`.
- This commit was pushed to `feat/sentiment-briefing-action-center` just after PR #20 was merged, so it did not land in `main`; without it the ruff gate on `main` fails with 3 F401 errors.

## Test plan
- [x] `ruff check src tests --select E9,F63,F7,F82,F401` — all checks passed
- [x] `pytest tests/agents/test_research_stream.py tests/services/test_daily_bars_factors.py tests/services/test_thesis_build.py` — 19 passed