### PR TITLE
feat(chat): surface concrete LLM error detail in chat reply

### DIFF
--- a/src/stockresearch/agents/orchestrator/stream.py
+++ b/src/stockresearch/agents/orchestrator/stream.py
@@ -28,6 +28,18 @@ def _llm_model_name(client: LLMClient) -> str:
     return str(getattr(client, "_model", "") or "")
 
 
+def _describe_request_error(exc: httpx.RequestError) -> str:
+    """把 httpx 网络错误转成可诊断的一句话:异常类型 + 目标主机(不含路径/密钥)。"""
+    kind = type(exc).__name__
+    try:
+        url = exc.request.url
+    except RuntimeError:
+        # httpx 的 request property 在未绑定请求时抛 RuntimeError
+        return kind
+    host = url.host or ""
+    return f"{kind}({host})" if host else kind
+
+
 def _resolve_master_on(
     request_flag: bool | None,
     settings: ModeSettingsOut,
@@ -200,18 +212,19 @@ async def _run_chat_stream_body(
             )
         except httpx.RequestError as exc:
             logger.exception("LLM request failed: %s", exc)
-            reply = "网络或 LLM 服务暂时不可用，请稍后重试。"
+            detail = _describe_request_error(exc)
+            reply = f"无法连接 LLM 服务（{detail}）。请检查网络或代理设置后重试。"
             partial = True
             await on_progress(
                 {
                     "type": "error",
                     "code": "llm_request_failed",
-                    "message": str(exc),
+                    "message": detail,
                 }
             )
         except Exception as exc:
             logger.exception("Chat stream turn failed: %s", exc)
-            reply = "抱歉，分析过程出错，请稍后重试。"
+            reply = f"分析过程出错（{type(exc).__name__}），请稍后重试。详细错误已记录到服务端日志。"
             partial = True
             await on_progress(
                 {

--- a/tests/agents/test_chat_stream_errors.py
+++ b/tests/agents/test_chat_stream_errors.py
@@ -1,0 +1,27 @@
+"""Chat stream 错误路径:面向用户的报错必须带可诊断细节。"""
+
+import httpx
+
+from stockresearch.agents.orchestrator.stream import _describe_request_error
+
+
+def test_describe_request_error_includes_type_and_host() -> None:
+    request = httpx.Request("POST", "https://apihub.agnes-ai.com/v1/chat/completions")
+    exc = httpx.ConnectTimeout("timed out", request=request)
+    assert _describe_request_error(exc) == "ConnectTimeout(apihub.agnes-ai.com)"
+
+
+def test_describe_request_error_without_request_falls_back_to_type() -> None:
+    exc = httpx.ConnectTimeout("timed out")
+    assert _describe_request_error(exc) == "ConnectTimeout"
+
+
+def test_describe_request_error_never_leaks_key_or_path() -> None:
+    request = httpx.Request(
+        "POST", "https://api.example.com/v1/chat/completions?api_key=sk-secret"
+    )
+    exc = httpx.ConnectError("boom", request=request)
+    detail = _describe_request_error(exc)
+    assert "sk-secret" not in detail
+    assert "/v1/chat" not in detail
+    assert "api.example.com" in detail


### PR DESCRIPTION
## Summary
- 对话界面在 LLM 网络失败时不再只显示「网络或 LLM 服务暂时不可用」,而是带上可诊断细节:异常类型 + 目标主机,例如 `无法连接 LLM 服务(ConnectTimeout(apihub.agnes-ai.com))`。
- 新增 `_describe_request_error()`:从 `httpx.RequestError` 提取异常类型与目标 host,不含 URL 路径与密钥;未绑定 request 时降级为仅类型名。
- 泛型异常分支的回复也带上异常类型名,并提示详见服务端日志;`error` 进度事件的 `message` 同步使用 detail(原来 `str(exc)` 对 httpx 超时为空串)。

## Test plan
- [x] 新增 `tests/agents/test_chat_stream_errors.py`(类型+host / 无 request 降级 / 不泄露密钥与路径)
- [x] `uv run pytest` — 525 passed, 3 skipped
- [x] `ruff check src tests --select E9,F63,F7,F82,F401` — all checks passed
- [ ] Manual: 断开代理后在 Copilot 提问,确认回复显示具体错误主机