### PR TITLE
feat(briefing): 盘前行业扫描 + 盘后复盘对照

### DIFF
--- a/src/stockresearch/services/briefing.py
+++ b/src/stockresearch/services/briefing.py
@@ -130,6 +130,43 @@ def _collect_market_block(overview) -> str:
     return "\n".join(lines)
 
 
+async def _collect_sector_block(kind: BriefingKind, holdings: list[Holding]) -> str:
+    """全市场行业板块涨跌榜，持仓相关行业单独标注。
+
+    盘前（未开盘）沿用上一交易日数据；盘中/盘后为当日数据。
+    """
+    from stockresearch.data.providers.sector import SectorDataProvider
+
+    label = "上一交易日" if kind == "premarket" else "今日"
+    try:
+        boards = await SectorDataProvider().fetch_industry_boards()
+    except Exception as exc:
+        logger.warning("Sector board fetch failed for briefing: %s", exc)
+        boards = []
+    if not boards:
+        return f"【行业板块（{label}）】\n行业板块数据暂不可用"
+
+    ranked = sorted(boards, key=lambda b: b.change_pct, reverse=True)
+    lines = [f"【行业板块（{label}）】", "涨幅居前："]
+    for b in ranked[:4]:
+        leader = f"，领涨 {b.leader_name}" if b.leader_name and b.leader_name != "—" else ""
+        lines.append(f"- {b.name} {b.change_pct:+.2f}%{leader}")
+    lines.append("跌幅居前：")
+    for b in ranked[-4:]:
+        lines.append(f"- {b.name} {b.change_pct:+.2f}%")
+
+    held_sectors = sorted({h.sector for h in holdings if h.sector})
+    hits: list[str] = []
+    for sector in held_sectors:
+        for b in boards:
+            if sector in b.name or b.name in sector:
+                hits.append(f"{b.name} {b.change_pct:+.2f}%")
+                break
+    if hits:
+        lines.append("持仓相关行业：" + "；".join(hits[:6]))
+    return "\n".join(lines)
+
+
 def _collect_kimi_block() -> str:
     """读取 Kimi 预取的宏观/Wind 缓存，格式化为简报 prompt 块。无数据返回空串。"""
     from stockresearch.data.providers.kimi_wind import WIND_CACHE_KEY
@@ -170,7 +207,7 @@ def _split_news(
     return holding, sector, market
 
 
-def _briefing_system_prompt(kind: BriefingKind) -> str:
+def _briefing_system_prompt(kind: BriefingKind, *, has_premarket_view: bool = False) -> str:
     phase = {"premarket": "盘前", "intraday": "盘中", "postmarket": "盘后"}[kind]
     if kind == "premarket":
         focus = (
@@ -180,16 +217,27 @@ def _briefing_system_prompt(kind: BriefingKind) -> str:
     elif kind == "intraday":
         focus = "侧重实时涨跌、盘中已发生事件对持仓的影响，以及新闻与行情的联动。"
     else:
-        focus = "侧重全天表现回顾、新闻脉络梳理，以及收盘后值得跟踪的风险点。"
+        focus = "侧重全天表现回顾、行业板块强弱梳理、新闻脉络梳理，以及收盘后值得跟踪的风险点。"
+
+    extra_rules = ""
+    if kind == "premarket":
+        extra_rules = (
+            "4. 结合行业板块强弱与相关新闻，在「持仓表现」段为每只持仓点出一句"
+            "「今日关注」（舆情/事件/所属板块强弱），只提示关注点，不给买卖建议\n"
+        )
+    elif kind == "postmarket" and has_premarket_view:
+        extra_rules = (
+            "4. 上下文提供了今日盘前简报观点，复盘时必须逐条对照：盘前提示的方向/关注点"
+            "今日是否兑现、偏差在哪里，并在结论中明说；盘前观点仅作参考，不逐字重复\n"
+        )
 
     return (
         f"你是A股持仓{phase}简报编辑。请根据下方事实数据撰写简报。\n"
         f"{focus}\n"
         "写作要求：\n"
-        "1. 必须综合：持仓表现、持仓相关新闻、大盘新闻、行业新闻，形成有深度的结论\n"
+        "1. 必须综合：持仓表现、行业板块强弱、持仓相关新闻、大盘新闻、行业新闻，形成有深度的结论\n"
         "2. 先摆事实，再给判断；结论要说清「对谁有利/不利、接下来关注什么」\n"
-        "3. 不荐股、不给具体买卖价位\n"
-        "4. 仅输出 JSON，不要 markdown 代码块：\n"
+        "3. 不荐股、不给具体买卖价位\n" + extra_rules + "仅输出 JSON，不要 markdown 代码块：\n"
         '{"summary":"80-150字开篇总览","sections":[{"title":"持仓表现","content":"..."},'
         '{"title":"新闻脉络","content":"..."},{"title":"综合结论","content":"..."}]}\n'
         "sections 固定 3 段，content 允许换行。"
@@ -227,6 +275,7 @@ def _fallback_sections(
     market_block: str,
     alerts: list[RiskAlertRecord],
     kimi_block: str = "",
+    sector_block: str = "",
 ) -> tuple[str, list[BriefingSection]]:
     news_content = "\n\n".join(
         [
@@ -237,7 +286,16 @@ def _fallback_sections(
     )
     sections = [
         BriefingSection(title="持仓表现", content=holdings_block.replace("【持仓表现】\n", "")),
-        BriefingSection(title="新闻脉络", content=news_content),
+    ]
+    if sector_block:
+        sections.append(
+            BriefingSection(
+                title="行业板块",
+                content=sector_block.split("\n", 1)[1] if "\n" in sector_block else sector_block,
+            )
+        )
+    sections.append(BriefingSection(title="新闻脉络", content=news_content))
+    sections.append(
         BriefingSection(
             title="综合结论",
             content=(
@@ -248,8 +306,8 @@ def _fallback_sections(
                     else "暂无新增风控提醒，建议继续跟踪持仓波动与相关新闻。"
                 )
             ),
-        ),
-    ]
+        )
+    )
     # 降级简报同样展示 Kimi 预取的宏观/市场数据块
     if kimi_block:
         sections.append(BriefingSection(title="宏观与市场动态(Kimi)", content=kimi_block))
@@ -269,7 +327,9 @@ async def generate_briefing(
     kind: str,
     *,
     llm: LLMClient | None = None,
+    premarket_view: str | None = None,
 ) -> BriefingOut:
+    """Generate a briefing; postmarket callers may pass the morning premarket view for recap."""
     normalized = normalize_briefing_kind(kind)
     title = briefing_title(normalized)
 
@@ -287,12 +347,14 @@ async def generate_briefing(
     holding_news, sector_news, market_news = _split_news(news)
     holdings_block = await _collect_holdings_block(holdings, normalized)
     market_block = _collect_market_block(overview)
+    sector_block = await _collect_sector_block(normalized, holdings)
     kimi_block = _collect_kimi_block()
 
     context_parts = [
         f"简报类型：{title}",
         holdings_block,
         market_block,
+        sector_block,
     ]
     if kimi_block:
         context_parts.append(kimi_block)
@@ -307,6 +369,9 @@ async def generate_briefing(
         context_parts.append(
             "【风控提醒】\n" + "\n".join(f"- [{a.severity}] {a.message}" for a in alerts)
         )
+    has_premarket_view = bool(premarket_view and premarket_view.strip())
+    if normalized == "postmarket" and has_premarket_view:
+        context_parts.append("【今日盘前简报观点（复盘对照用）】\n" + premarket_view.strip()[:1200])
     context = "\n\n".join(context_parts)
 
     summary: str | None = None
@@ -314,7 +379,10 @@ async def generate_briefing(
 
     if llm is not None:
         try:
-            raw = await llm.complete(_briefing_system_prompt(normalized), context)
+            raw = await llm.complete(
+                _briefing_system_prompt(normalized, has_premarket_view=has_premarket_view),
+                context,
+            )
             parsed = _parse_llm_briefing(raw)
             if parsed:
                 summary, sections = parsed
@@ -331,6 +399,7 @@ async def generate_briefing(
             market_block=market_block,
             alerts=alerts,
             kimi_block=kimi_block,
+            sector_block=sector_block,
         )
         if llm is not None:
             try:

--- a/src/stockresearch/services/briefing_scheduler.py
+++ b/src/stockresearch/services/briefing_scheduler.py
@@ -160,8 +160,14 @@ class BriefingScheduler:
             logger.info("%s briefing already exists for user %s today", normalized, user_id)
             return
 
+        premarket_view: str | None = None
+        if normalized == "postmarket":
+            premarket_view = self._morning_view(db, user_id, start, end)
+
         logger.info("Generating %s briefing for user %s", normalized, user_id)
-        briefing = await generate_briefing(db, user_id, normalized, llm=LLMClient())
+        briefing = await generate_briefing(
+            db, user_id, normalized, llm=LLMClient(), premarket_view=premarket_view
+        )
         generated_at = briefing.generated_at
         if generated_at.tzinfo:
             generated_at = generated_at.replace(tzinfo=None)
@@ -176,6 +182,34 @@ class BriefingScheduler:
         db.add(record)
         db.commit()
         logger.info("Saved %s briefing for user %s", normalized, user_id)
+
+    @staticmethod
+    def _morning_view(db: Session, user_id: int, start: datetime, end: datetime) -> str | None:
+        """当日盘前简报观点（summary + 各段），供盘后复盘对照；无则 None。"""
+        morning = (
+            db.query(BriefingRecord)
+            .filter(
+                BriefingRecord.user_id == user_id,
+                BriefingRecord.kind.in_(briefing_kind_aliases("premarket")),
+                BriefingRecord.generated_at >= start,
+                BriefingRecord.generated_at <= end,
+            )
+            .order_by(BriefingRecord.generated_at.desc())
+            .first()
+        )
+        if morning is None:
+            return None
+        parts: list[str] = []
+        if morning.summary:
+            parts.append(morning.summary)
+        for section in morning.sections or []:
+            if not isinstance(section, dict):
+                continue
+            title = str(section.get("title", "")).strip()
+            content = str(section.get("content", "")).strip()
+            if title and content:
+                parts.append(f"{title}：{content}")
+        return "\n".join(parts)[:1500] or None
 
 
 scheduler = BriefingScheduler()

--- a/tests/services/test_briefing_daily_scan.py
+++ b/tests/services/test_briefing_daily_scan.py
@@ -1,0 +1,183 @@
+"""Daily-scan briefing enhancements: sector ranking block + postmarket recap."""
+
+import uuid
+from datetime import date, datetime, time, timedelta
+
+import pytest
+
+from stockresearch.data.providers import sector as sector_mod
+from stockresearch.data.providers.sector import SectorBoard
+from stockresearch.db.models import BriefingRecord, User
+from stockresearch.services.briefing import (
+    _briefing_system_prompt,
+    _collect_sector_block,
+    _fallback_sections,
+)
+from stockresearch.services.briefing_scheduler import BriefingScheduler
+
+_BOARDS = [
+    SectorBoard(
+        code="BK1",
+        name="半导体",
+        change_pct=3.2,
+        leader_name="中芯国际",
+        leader_symbol="688981",
+        leader_change_pct=7.1,
+    ),
+    SectorBoard(
+        code="BK2",
+        name="白酒",
+        change_pct=1.1,
+        leader_name="贵州茅台",
+        leader_symbol="600519",
+        leader_change_pct=1.8,
+    ),
+    SectorBoard(
+        code="BK3",
+        name="券商",
+        change_pct=0.5,
+        leader_name="",
+        leader_symbol="",
+        leader_change_pct=0.0,
+    ),
+    SectorBoard(
+        code="BK4",
+        name="煤炭",
+        change_pct=-1.2,
+        leader_name="",
+        leader_symbol="",
+        leader_change_pct=0.0,
+    ),
+    SectorBoard(
+        code="BK5",
+        name="房地产开发",
+        change_pct=-2.4,
+        leader_name="—",
+        leader_symbol="",
+        leader_change_pct=0.0,
+    ),
+]
+
+
+def _patch_boards(monkeypatch: pytest.MonkeyPatch, boards: list[SectorBoard]) -> None:
+    async def _fake(self) -> list[SectorBoard]:
+        return boards
+
+    monkeypatch.setattr(sector_mod.SectorDataProvider, "fetch_industry_boards", _fake)
+
+
+class _FakeHolding:
+    def __init__(self, sector: str) -> None:
+        self.sector = sector
+
+
+async def test_sector_block_premarket_ranking_and_held_sector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_boards(monkeypatch, _BOARDS)
+    block = await _collect_sector_block("premarket", [_FakeHolding("白酒")])  # type: ignore[arg-type]
+    assert "上一交易日" in block
+    assert "涨幅居前" in block and "跌幅居前" in block
+    assert "半导体 +3.20%" in block and "领涨 中芯国际" in block
+    assert "房地产开发 -2.40%" in block
+    assert "持仓相关行业：白酒 +1.10%" in block
+
+
+async def test_sector_block_intraday_uses_today_label(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_boards(monkeypatch, _BOARDS)
+    block = await _collect_sector_block("postmarket", [])
+    assert "今日" in block and "上一交易日" not in block
+
+
+async def test_sector_block_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_boards(monkeypatch, [])
+    block = await _collect_sector_block("premarket", [])
+    assert "行业板块数据暂不可用" in block
+
+
+def test_premarket_prompt_requires_focus_points() -> None:
+    prompt = _briefing_system_prompt("premarket")
+    assert "今日关注" in prompt
+    assert "不给买卖建议" in prompt
+
+
+def test_postmarket_prompt_recap_only_with_premarket_view() -> None:
+    without = _briefing_system_prompt("postmarket")
+    assert "逐条对照" not in without
+    with_view = _briefing_system_prompt("postmarket", has_premarket_view=True)
+    assert "逐条对照" in with_view and "盘前" in with_view
+
+
+def test_fallback_sections_include_sector_block() -> None:
+    _, sections = _fallback_sections(
+        kind="postmarket",
+        holdings_block="【持仓表现】\n- 示例",
+        holding_news=[],
+        sector_news=[],
+        market_news=[],
+        market_block="【大盘概况】\n指数数据暂不可用",
+        alerts=[],
+        sector_block="【行业板块（今日）】\n涨幅居前：\n- 半导体 +3.20%",
+    )
+    titles = [s.title for s in sections]
+    assert "行业板块" in titles
+    sector_section = sections[titles.index("行业板块")]
+    assert "半导体" in sector_section.content
+    assert "【行业板块" not in sector_section.content
+
+
+def test_fallback_sections_omit_sector_block_when_empty() -> None:
+    _, sections = _fallback_sections(
+        kind="intraday",
+        holdings_block="【持仓表现】\n- 示例",
+        holding_news=[],
+        sector_news=[],
+        market_news=[],
+        market_block="【大盘概况】\n指数数据暂不可用",
+        alerts=[],
+        sector_block="",
+    )
+    assert "行业板块" not in [s.title for s in sections]
+
+
+@pytest.fixture()
+def user(db_session):
+    u = User(username=f"brief-{uuid.uuid4().hex[:8]}", password_hash="x")
+    db_session.add(u)
+    db_session.commit()
+    db_session.refresh(u)
+    return u
+
+
+def _day_bounds() -> tuple[datetime, datetime]:
+    today = date.today()
+    return datetime.combine(today, time.min), datetime.combine(today, time.max)
+
+
+def test_morning_view_returns_summary_and_sections(db_session, user) -> None:
+    start, end = _day_bounds()
+    db_session.add(
+        BriefingRecord(
+            user_id=user.id,
+            kind="premarket",
+            title="盘前简报",
+            summary="关注半导体链与北向动向",
+            sections=[
+                {"title": "持仓表现", "content": "茅台盘前参考价为昨收"},
+                {"title": "综合结论", "content": "留意白酒板块强弱"},
+            ],
+            generated_at=datetime.now() - timedelta(minutes=1),
+        )
+    )
+    db_session.commit()
+
+    view = BriefingScheduler._morning_view(db_session, user.id, start, end)
+    assert view is not None
+    assert "关注半导体链与北向动向" in view
+    assert "持仓表现：茅台盘前参考价为昨收" in view
+    assert "综合结论：留意白酒板块强弱" in view
+
+
+def test_morning_view_none_without_premarket(db_session, user) -> None:
+    start, end = _day_bounds()
+    assert BriefingScheduler._morning_view(db_session, user.id, start, end) is None


### PR DESCRIPTION
简报增强：盘前/盘后简报新增行业板块涨跌榜块（持仓所属行业标注）；盘后简报注入当日盘前观点做复盘对照；盘前 prompt 强化「今日关注」；新增 13 项测试。pytest 588 passed + npm build 通过。