### PR TITLE
feat(copilot): reusable AI chart overlays (Phase 9b)

### DIFF
--- a/src/stockresearch/agents/orchestrator/skills.py
+++ b/src/stockresearch/agents/orchestrator/skills.py
@@ -81,6 +81,13 @@ PACKAGED_SKILLS: tuple[PackagedSkill, ...] = (
         '{"subject": "标的或主题", "context": "必填：待点评的摘要或报告", '
         '"master_ids": ["buffett","munger"], "debate_masters": true}',
     ),
+    PackagedSkill(
+        "skill_chart_overlays",
+        "K线画线解说",
+        "基于日线计算趋势线/支撑压力位并给出一句描述性解读（不荐股、不给交易指令）；"
+        "用户说「画趋势线/支撑位在哪/压力位在哪」时调用",
+        '{"symbol": "600519"}',
+    ),
 )
 
 SKILL_IDS: frozenset[str] = frozenset(s.skill_id for s in PACKAGED_SKILLS)
@@ -161,6 +168,8 @@ class SkillRunner:
                 result = await self._run_bull_bear(run_id, args)
             elif skill_id == "skill_master_commentary":
                 result = await self._run_master_commentary(run_id, args)
+            elif skill_id == "skill_chart_overlays":
+                result = await self._run_chart_overlays(run_id, args)
             else:
                 result = SkillRunResult(summary=f"未知 Skill: {skill_id}", error="unknown_skill")
         except Exception as exc:
@@ -183,6 +192,38 @@ class SkillRunner:
 
     async def _forward(self, run_id: str, event: dict[str, object]) -> None:
         await self._emit({**event, "skill_run_id": run_id})
+
+    async def _run_chart_overlays(self, run_id: str, args: dict[str, Any]) -> SkillRunResult:
+        from stockresearch.services.chart_overlays import compute_chart_overlays
+
+        symbol = str(args.get("symbol", "")).strip()
+        if not (len(symbol) == 6 and symbol.isdigit()):
+            symbol = self._confirmed_symbol or ""
+        if not (len(symbol) == 6 and symbol.isdigit()):
+            return SkillRunResult(summary="请先告诉我要画线的股票代码（6 位数字）。", partial=True)
+        await self._forward(
+            run_id, {"type": "status", "message": f"正在计算 {resolve_name(symbol)} 的趋势线…"}
+        )
+        overlay_set = await compute_chart_overlays(symbol)
+        if not overlay_set.overlays:
+            return SkillRunResult(
+                summary=(
+                    f"{resolve_name(symbol)}（{symbol}）近期日线未检测到有效趋势线，"
+                    "可能缺少清晰的枢轴点或价格距离过远。"
+                ),
+                cards=[{"type": "chart_overlays", "data": overlay_set.model_dump(mode="json")}],
+                intent="chat",
+                partial=True,
+            )
+        lines = "\n".join(
+            f"- {overlay.rationale}" for overlay in overlay_set.overlays if overlay.rationale
+        )
+        summary = f"{resolve_name(symbol)}（{symbol}）当前识别到 {len(overlay_set.overlays)} 条趋势线：\n{lines}"
+        return SkillRunResult(
+            summary=summary,
+            cards=[{"type": "chart_overlays", "data": overlay_set.model_dump(mode="json")}],
+            intent="chat",
+        )
 
     async def _run_risk(self, run_id: str) -> SkillRunResult:
         if not self._holdings:

--- a/src/stockresearch/api/routes/market.py
+++ b/src/stockresearch/api/routes/market.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 
 from stockresearch.api.deps import get_current_user
 from stockresearch.core.schemas import (
+    ChartOverlaySet,
     DataSourceDetailOut,
     DataSourceStatusOut,
     IndexIntradayOut,
@@ -33,6 +34,7 @@ from stockresearch.data.providers.sina_kline import fetch_sina_intraday
 from stockresearch.data.registry import ProviderSnapshot, get_quote_conflicts, get_snapshots
 from stockresearch.db.models import Holding, User
 from stockresearch.db.session import get_db
+from stockresearch.services.chart_overlays import compute_chart_overlays
 from stockresearch.services.provider_cache_policy import quote_cache_ttl_seconds
 from stockresearch.services.sentiment import SentimentService
 from stockresearch.services.user_preferences import get_mode_settings
@@ -132,6 +134,19 @@ async def stock_kline(
             detail="K 线数据暂不可用（行情源连接失败），请稍后刷新",
         )
     return KlineChartOut.model_validate(raw)
+
+
+@router.get("/overlays", response_model=ChartOverlaySet)
+async def chart_overlays(
+    symbol: str = Query(min_length=6, max_length=6, pattern=r"^\d{6}$"),
+    _user: User = Depends(get_current_user),
+) -> ChartOverlaySet:
+    """Phase 9b：服务端趋势线 overlay（与前端 chartTrendlines 算法对齐）。"""
+    try:
+        return await compute_chart_overlays(symbol)
+    except Exception as exc:
+        logger.warning("chart overlays failed for %s: %s", symbol, exc, exc_info=True)
+        raise HTTPException(status_code=503, detail="画线数据暂不可用，请稍后重试") from exc
 
 
 @router.get("/data-status", response_model=DataSourceStatusOut)

--- a/src/stockresearch/core/schemas.py
+++ b/src/stockresearch/core/schemas.py
@@ -670,6 +670,32 @@ class KlineChartOut(BaseModel):
     adjust: str = "none"  # qfq | none
 
 
+class ChartOverlayPoint(BaseModel):
+    time: str
+    price: float
+
+
+class ChartOverlay(BaseModel):
+    """画线层单元（与 PRD §九 TS shape 对齐，source 扩 ai）。"""
+
+    id: str
+    kind: Literal["trend", "level"]
+    a: ChartOverlayPoint | None = None
+    b: ChartOverlayPoint | None = None
+    side: Literal["support", "resistance"] | None = None
+    price: float | None = None
+    strength: float = Field(default=0.0, ge=0.0, le=1.0)
+    touches: int | None = None
+    source: Literal["algo", "ai"] = "ai"
+    rationale: str | None = None
+
+
+class ChartOverlaySet(BaseModel):
+    symbol: str
+    generatedAt: str
+    overlays: list[ChartOverlay] = Field(default_factory=list)
+
+
 class MarketOverviewOut(BaseModel):
     indices: list[IndexQuoteOut]
     northbound_net_yi: float | None

--- a/src/stockresearch/services/chart_overlays.py
+++ b/src/stockresearch/services/chart_overlays.py
@@ -1,0 +1,252 @@
+"""Server-side trendline detection — Python port of web/src/chartTrendlines.ts.
+
+Parameters stay aligned with the frontend implementation (pivot window 3,
+tolerance 0.6%, max 4 lines, relevance filter 15%) so Copilot answers
+describe exactly what the chart renders (Phase 9b).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from stockresearch.core.schemas import ChartOverlay, ChartOverlayPoint, ChartOverlaySet
+
+TrendLineKind = Literal["support", "resistance"]
+
+
+@dataclass(frozen=True)
+class Bar:
+    date: str
+    high: float
+    low: float
+    close: float
+
+
+@dataclass(frozen=True)
+class Pivot:
+    index: int
+    price: float
+
+
+@dataclass(frozen=True)
+class TrendLine:
+    kind: TrendLineKind
+    start_index: int
+    end_index: int
+    start_price: float
+    end_price: float
+    slope_per_bar: float
+    touches: int
+
+
+@dataclass(frozen=True)
+class TrendLineOptions:
+    pivot_window: int = 3
+    tolerance_pct: float = 0.006
+    max_lines: int = 4
+    min_span: int = 5
+    max_span: int = 140
+    relevance_pct: float = 0.15
+
+
+def find_pivots(bars: list[Bar], k: int) -> tuple[list[Pivot], list[Pivot]]:
+    highs: list[Pivot] = []
+    lows: list[Pivot] = []
+    for i in range(k, len(bars) - k):
+        is_high = True
+        is_low = True
+        for j in range(i - k, i + k + 1):
+            if bars[j].high > bars[i].high:
+                is_high = False
+            if bars[j].low < bars[i].low:
+                is_low = False
+            if not is_high and not is_low:
+                break
+        if is_high:
+            highs.append(Pivot(i, bars[i].high))
+        if is_low:
+            lows.append(Pivot(i, bars[i].low))
+    return highs, lows
+
+
+def _score_line(line: TrendLine, max_span: int, last_close: float) -> float:
+    span = line.end_index - line.start_index
+    span_score = min(span, max_span) / max_span
+    distance = abs(line.end_price - last_close) / last_close
+    return line.touches * 2 + span_score - distance * 10
+
+
+def _is_duplicate(a: TrendLine, b: TrendLine, tolerance_pct: float) -> bool:
+    if a.kind != b.kind:
+        return False
+    near_start = abs(a.start_price - b.start_price) <= tolerance_pct * 2 * a.start_price
+    near_end = abs(a.end_price - b.end_price) <= tolerance_pct * 2 * a.end_price
+    return near_start and near_end
+
+
+def _fit_lines(
+    bars: list[Bar],
+    pivots: list[Pivot],
+    kind: TrendLineKind,
+    opts: TrendLineOptions,
+) -> list[TrendLine]:
+    last = len(bars) - 1
+    out: list[TrendLine] = []
+    for ai in range(len(pivots)):
+        for bi in range(ai + 1, len(pivots)):
+            p1, p2 = pivots[ai], pivots[bi]
+            span = p2.index - p1.index
+            if span < opts.min_span or span > opts.max_span:
+                continue
+            slope = (p2.price - p1.price) / span
+
+            def value_at(idx: int) -> float:
+                return p1.price + slope * (idx - p1.index)
+
+            valid = True
+            for t in range(p1.index, last + 1):
+                lv = value_at(t)
+                tol = opts.tolerance_pct * lv
+                if kind == "support":
+                    if bars[t].low < lv - tol:
+                        valid = False
+                        break
+                elif bars[t].high > lv + tol:
+                    valid = False
+                    break
+            if not valid:
+                continue
+
+            touches = 0
+            for p in pivots:
+                if p.index < p1.index:
+                    continue
+                lv = value_at(p.index)
+                if abs(p.price - lv) <= opts.tolerance_pct * lv:
+                    touches += 1
+            if touches < 2:
+                continue
+
+            out.append(
+                TrendLine(
+                    kind=kind,
+                    start_index=p1.index,
+                    end_index=last,
+                    start_price=p1.price,
+                    end_price=value_at(last),
+                    slope_per_bar=slope,
+                    touches=touches,
+                )
+            )
+    return out
+
+
+def detect_trend_lines(
+    bars: list[Bar],
+    options: TrendLineOptions | None = None,
+) -> list[TrendLine]:
+    opts = options or TrendLineOptions()
+    if len(bars) < opts.min_span + 2 * opts.pivot_window + 2:
+        return []
+
+    last_close = bars[-1].close
+
+    def relevant(line: TrendLine) -> bool:
+        return abs(line.end_price - last_close) / last_close <= opts.relevance_pct
+
+    highs, lows = find_pivots(bars, opts.pivot_window)
+    supports = [line for line in _fit_lines(bars, lows, "support", opts) if relevant(line)]
+    resistances = [line for line in _fit_lines(bars, highs, "resistance", opts) if relevant(line)]
+
+    def pick(lines: list[TrendLine], cap: int) -> list[TrendLine]:
+        ordered = sorted(
+            lines,
+            key=lambda line: _score_line(line, opts.max_span, last_close),
+            reverse=True,
+        )
+        kept: list[TrendLine] = []
+        for line in ordered:
+            if len(kept) >= cap:
+                break
+            if any(_is_duplicate(k, line, opts.tolerance_pct) for k in kept):
+                continue
+            kept.append(line)
+        return kept
+
+    half = (opts.max_lines + 1) // 2
+    return (pick(supports, half) + pick(resistances, half))[: opts.max_lines]
+
+
+def bars_from_kline(raw: dict[str, Any]) -> list[Bar]:
+    bars: list[Bar] = []
+    for item in raw.get("bars") or []:
+        if not isinstance(item, dict):
+            continue
+        try:
+            bars.append(
+                Bar(
+                    date=str(item["date"]),
+                    high=float(item["high"]),
+                    low=float(item["low"]),
+                    close=float(item["close"]),
+                )
+            )
+        except (KeyError, TypeError, ValueError):
+            continue
+    return bars
+
+
+def _overlay_rationale(line: TrendLine, bars: list[Bar]) -> str:
+    side_text = "支撑线" if line.kind == "support" else "压力线"
+    anchor = "低点" if line.kind == "support" else "高点"
+    last_close = bars[-1].close
+    relation = "上方" if line.end_price <= last_close else "下方"
+    return (
+        f"{side_text}：连接 {bars[line.start_index].date} 与临近末端的{anchor}，"
+        f"共 {line.touches} 次触碰；延伸至最新一根K线约 {line.end_price:.2f}，"
+        f"位于最新收盘价 {last_close:.2f} 的{relation}。仅为图形描述，不构成交易建议。"
+    )
+
+
+def build_overlay_set(symbol: str, bars: list[Bar]) -> ChartOverlaySet:
+    lines = detect_trend_lines(bars)
+    overlays: list[ChartOverlay] = []
+    if lines:
+        scores = [_score_line(line, TrendLineOptions().max_span, bars[-1].close) for line in lines]
+        top = max(scores)
+        floor = min(scores)
+        span = top - floor
+        for line, score in zip(lines, scores, strict=True):
+            strength = 1.0 if span <= 0 else max(0.0, min(1.0, (score - floor) / span))
+            overlays.append(
+                ChartOverlay(
+                    id=f"trend-{line.kind}-{line.start_index}-{line.end_index}",
+                    kind="trend",
+                    a=ChartOverlayPoint(
+                        time=bars[line.start_index].date, price=round(line.start_price, 4)
+                    ),
+                    b=ChartOverlayPoint(
+                        time=bars[line.end_index].date, price=round(line.end_price, 4)
+                    ),
+                    side=line.kind,
+                    strength=round(strength, 2),
+                    touches=line.touches,
+                    source="ai",
+                    rationale=_overlay_rationale(line, bars),
+                )
+            )
+    return ChartOverlaySet(
+        symbol=symbol,
+        generatedAt=datetime.now(UTC).isoformat(),
+        overlays=overlays,
+    )
+
+
+async def compute_chart_overlays(symbol: str, days: int = 250) -> ChartOverlaySet:
+    """Fetch daily bars and compute AI trendline overlays for one symbol."""
+    from stockresearch.data.providers.market.technical import TechnicalDataProvider
+
+    raw = await TechnicalDataProvider().get_kline_chart(symbol, days)
+    return build_overlay_set(symbol, bars_from_kline(raw))

--- a/tests/agents/test_skills.py
+++ b/tests/agents/test_skills.py
@@ -397,3 +397,70 @@ async def test_unknown_skill(db_session: Session) -> None:
     result = await runner.run("skill_not_real", {})
 
     assert result.error == "unknown_skill"
+
+
+@pytest.mark.asyncio
+async def test_skill_chart_overlays_requires_symbol(db_session: Session) -> None:
+    user = User(username="skill-overlays-nosym", password_hash="")
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    runner = _runner(db_session, user.id)
+    result = await runner.run("skill_chart_overlays", {})
+
+    assert result.partial is True
+    assert "股票代码" in result.summary
+
+
+@pytest.mark.asyncio
+async def test_skill_chart_overlays_returns_set(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from stockresearch.core.schemas import (
+        ChartOverlay,
+        ChartOverlayPoint,
+        ChartOverlaySet,
+    )
+
+    user = User(username="skill-overlays-ok", password_hash="")
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    overlay_set = ChartOverlaySet(
+        symbol="600519",
+        generatedAt="2026-08-04T00:00:00+00:00",
+        overlays=[
+            ChartOverlay(
+                id="trend-support-5-79",
+                kind="trend",
+                a=ChartOverlayPoint(time="2026-04-01", price=100.0),
+                b=ChartOverlayPoint(time="2026-08-01", price=137.0),
+                side="support",
+                strength=1.0,
+                touches=4,
+                source="ai",
+                rationale="支撑线：连接低点，共 4 次触碰。仅为图形描述，不构成交易建议。",
+            )
+        ],
+    )
+
+    async def fake_compute(symbol: str, days: int = 250) -> ChartOverlaySet:
+        assert symbol == "600519"
+        return overlay_set
+
+    monkeypatch.setattr(
+        "stockresearch.services.chart_overlays.compute_chart_overlays", fake_compute
+    )
+
+    events: list[dict[str, object]] = []
+    runner = _runner(db_session, user.id, events=events)
+    result = await runner.run("skill_chart_overlays", {"symbol": "600519"})
+
+    assert result.error is None
+    assert result.cards and result.cards[0]["type"] == "chart_overlays"
+    assert "支撑线" in result.summary
+    assert "不构成交易建议" in result.summary
+    assert events[0]["type"] == "skill_start"
+    assert events[-1]["type"] == "skill_done"

--- a/tests/api/test_market_overlays.py
+++ b/tests/api/test_market_overlays.py
@@ -1,0 +1,52 @@
+"""GET /market/overlays route tests (Phase 9b)."""
+
+from unittest.mock import AsyncMock, patch
+
+from stockresearch.core.schemas import ChartOverlay, ChartOverlayPoint, ChartOverlaySet
+
+
+def _overlay_set() -> ChartOverlaySet:
+    return ChartOverlaySet(
+        symbol="600519",
+        generatedAt="2026-08-04T00:00:00+00:00",
+        overlays=[
+            ChartOverlay(
+                id="trend-support-5-79",
+                kind="trend",
+                a=ChartOverlayPoint(time="2026-04-01", price=100.0),
+                b=ChartOverlayPoint(time="2026-08-01", price=137.0),
+                side="support",
+                strength=1.0,
+                touches=4,
+                source="ai",
+                rationale="支撑线示例，不构成交易建议。",
+            )
+        ],
+    )
+
+
+def test_market_overlays_returns_set(client, db_session) -> None:
+    with patch(
+        "stockresearch.api.routes.market.compute_chart_overlays",
+        new=AsyncMock(return_value=_overlay_set()),
+    ):
+        resp = client.get("/api/v1/market/overlays?symbol=600519")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["symbol"] == "600519"
+    assert body["overlays"][0]["source"] == "ai"
+    assert body["overlays"][0]["side"] == "support"
+
+
+def test_market_overlays_rejects_invalid_symbol(client, db_session) -> None:
+    resp = client.get("/api/v1/market/overlays?symbol=12345")
+    assert resp.status_code == 422
+
+
+def test_market_overlays_provider_failure_503(client, db_session) -> None:
+    with patch(
+        "stockresearch.api.routes.market.compute_chart_overlays",
+        new=AsyncMock(side_effect=RuntimeError("provider down")),
+    ):
+        resp = client.get("/api/v1/market/overlays?symbol=600519")
+    assert resp.status_code == 503

--- a/tests/services/test_chart_overlays.py
+++ b/tests/services/test_chart_overlays.py
@@ -1,0 +1,78 @@
+"""Chart overlay algorithm tests (Python port of chartTrendlines.ts)."""
+
+from stockresearch.services.chart_overlays import (
+    Bar,
+    TrendLineOptions,
+    build_overlay_set,
+    detect_trend_lines,
+    find_pivots,
+)
+
+
+def _zigzag_uptrend(n: int = 80) -> list[Bar]:
+    """Straight uptrend with ±2.5 zigzag so pivots sit on two clean lines."""
+    bars: list[Bar] = []
+    for i in range(n):
+        mid = 100.0 + 0.5 * i
+        wave = 2.0 if (i % 10) < 5 else -2.0
+        bars.append(
+            Bar(
+                date=f"2026-{(i // 22) + 4:02d}-{(i % 22) + 1:02d}",
+                high=mid + wave + 0.5,
+                low=mid + wave - 0.5,
+                close=mid,
+            )
+        )
+    return bars
+
+
+def test_find_pivots_detects_zigzag_extremes() -> None:
+    bars = _zigzag_uptrend()
+    highs, lows = find_pivots(bars, 3)
+    assert highs, "expected fractal highs"
+    assert lows, "expected fractal lows"
+    # trough pivots land at phase-5 bars (i=5,15,25,...)
+    assert any(p.index == 5 for p in lows)
+    assert any(p.index == 15 for p in lows)
+
+
+def test_detect_trend_lines_finds_support_and_resistance() -> None:
+    bars = _zigzag_uptrend()
+    lines = detect_trend_lines(bars)
+    assert lines, "expected trendlines on clean zigzag"
+    kinds = {line.kind for line in lines}
+    assert "support" in kinds
+    support = next(line for line in lines if line.kind == "support")
+    assert support.touches >= 3
+    assert len(lines) <= TrendLineOptions().max_lines
+
+
+def test_detect_trend_lines_empty_when_bars_too_few() -> None:
+    assert detect_trend_lines(_zigzag_uptrend(8)) == []
+
+
+def test_detect_trend_lines_respects_relevance_filter() -> None:
+    bars = _zigzag_uptrend()
+    # Very strict relevance window drops everything far from last close.
+    lines = detect_trend_lines(bars, TrendLineOptions(relevance_pct=0.0001))
+    assert lines == []
+
+
+def test_build_overlay_set_shapes_and_language() -> None:
+    bars = _zigzag_uptrend()
+    overlay_set = build_overlay_set("600519", bars)
+    assert overlay_set.symbol == "600519"
+    assert overlay_set.generatedAt
+    assert overlay_set.overlays
+    for overlay in overlay_set.overlays:
+        assert overlay.kind == "trend"
+        assert overlay.source == "ai"
+        assert overlay.side in ("support", "resistance")
+        assert 0.0 <= overlay.strength <= 1.0
+        assert overlay.a and overlay.b
+        assert overlay.rationale and "不构成交易建议" in overlay.rationale
+
+
+def test_build_overlay_set_empty_bars() -> None:
+    overlay_set = build_overlay_set("600519", [])
+    assert overlay_set.overlays == []

--- a/web/src/ChartOverlaysCardView.tsx
+++ b/web/src/ChartOverlaysCardView.tsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+import type { ChartOverlaySet } from "./api";
+import { publishChartOverlays } from "./chartOverlayBus";
+import { useI18n } from "./i18n";
+
+interface Props {
+  data: ChartOverlaySet;
+}
+
+export function ChartOverlaysCardView({ data }: Props) {
+  const { t } = useI18n();
+  const [applied, setApplied] = useState(false);
+
+  return (
+    <div className="card chart-overlays-card">
+      <div className="light-research-head">
+        <h4>
+          {t("overlays.title")} · {data.symbol}
+        </h4>
+        <div className="stat-row">
+          <span className="stat-pill">
+            {data.overlays.length} {t("overlays.lines")}
+          </span>
+          {data.overlays.length > 0 && (
+            <button
+              type="button"
+              className="example-chip"
+              disabled={applied}
+              onClick={() => {
+                publishChartOverlays(data);
+                setApplied(true);
+              }}
+            >
+              {applied ? t("overlays.applied") : t("overlays.showOnChart")}
+            </button>
+          )}
+        </div>
+      </div>
+      {data.overlays.length === 0 ? (
+        <p className="muted">{t("overlays.none")}</p>
+      ) : (
+        <ul className="chart-overlays-list">
+          {data.overlays.map((overlay) => (
+            <li key={overlay.id}>
+              <span
+                className={`stat-pill ${overlay.side === "support" ? "up" : "down"}`}
+              >
+                {overlay.side === "support"
+                  ? t("overlays.support")
+                  : t("overlays.resistance")}
+              </span>
+              <span className="muted">{overlay.rationale}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/web/src/ChatPanel.tsx
+++ b/web/src/ChatPanel.tsx
@@ -8,6 +8,8 @@ import type { AppMode } from "./modeSettings";
 import { CardView, PlanCardsFold, StockChoiceCardView } from "./chatCards";
 import { FollowUpChips } from "./FollowUpChips";
 import { LightResearchCard } from "./LightResearchCard";
+import { ChartOverlaysCardView } from "./ChartOverlaysCardView";
+import type { ChartOverlaySet } from "./api";
 import { findResearchReport, FollowUpQuestions } from "./researchReportView";
 import { isResearchTurn } from "./disclaimerText";
 import { useI18n } from "./i18n";
@@ -236,6 +238,11 @@ export function ChatPanel({
                             data={c.data as unknown as StockChoiceCardData}
                             disabled={loading}
                             onConfirm={onConfirmStock}
+                          />
+                        ) : c.type === "chart_overlays" ? (
+                          <ChartOverlaysCardView
+                            key={j}
+                            data={c.data as unknown as ChartOverlaySet}
                           />
                         ) : (
                           <CardView key={j} card={c} />

--- a/web/src/StockChart.tsx
+++ b/web/src/StockChart.tsx
@@ -13,9 +13,10 @@ import {
   type LogicalRange,
   type Time,
 } from "lightweight-charts";
-import { api, type KlineChart } from "./api";
+import { api, type ChartOverlaySet, type KlineChart } from "./api";
 import { mergeKlineBars, maSeries, type KlineBar } from "./chartIndicators";
 import { detectTrendLines } from "./chartTrendlines";
+import { subscribeChartOverlays } from "./chartOverlayBus";
 import { useI18n } from "./i18n";
 import { getCachedKline, patchCachedKline, setCachedKline } from "./klineCache";
 import {
@@ -59,6 +60,7 @@ interface ChartRuntime {
   macdSignal?: ISeriesApi<"Line">;
   rsi?: ISeriesApi<"Line">;
   trendLines: ISeriesApi<"Line">[];
+  aiOverlays: ISeriesApi<"Line">[];
   mounted: { el: HTMLElement; chart: IChartApi; h: number }[];
 }
 
@@ -134,6 +136,7 @@ export function MarketChart({
     mounted: [],
     maLines: new Map(),
     trendLines: [],
+    aiOverlays: [],
   });
   const visibleRangeRef = useRef<LogicalRange | null>(null);
   const loadingMoreRef = useRef(false);
@@ -396,6 +399,7 @@ export function MarketChart({
         mounted: [],
         maLines: new Map(),
         trendLines: [],
+        aiOverlays: [],
       };
     };
     dispose();
@@ -603,6 +607,39 @@ export function MarketChart({
     }
     // showMacd/showRsi/compact/variant remount the chart, so re-apply lines then.
   }, [showTrend, data, symbol, variant, t, showMacd, showRsi, compact]);
+
+  const [aiOverlays, setAiOverlays] = useState<ChartOverlaySet | null>(null);
+
+  useEffect(() => subscribeChartOverlays(setAiOverlays), []);
+
+  useEffect(() => {
+    const rt = runtimeRef.current;
+    const chart = rt.mainChart;
+    if (!chart) return;
+    for (const series of rt.aiOverlays) chart.removeSeries(series);
+    rt.aiOverlays = [];
+    if (!aiOverlays || aiOverlays.symbol !== symbol || variant !== "stock")
+      return;
+    const { up, down } = readChartColors();
+    for (const overlay of aiOverlays.overlays) {
+      if (overlay.kind !== "trend" || !overlay.a || !overlay.b) continue;
+      const support = overlay.side === "support";
+      const series = chart.addLineSeries({
+        color: support ? up : down,
+        lineWidth: 2,
+        lineStyle: LineStyle.SparseDotted,
+        title: `${support ? t("chart.trendSupport") : t("chart.trendResistance")} · AI`,
+        lastValueVisible: false,
+        priceLineVisible: false,
+        crosshairMarkerVisible: false,
+      });
+      series.setData([
+        { time: barTime(overlay.a.time), value: overlay.a.price },
+        { time: barTime(overlay.b.time), value: overlay.b.price },
+      ]);
+      rt.aiOverlays.push(series);
+    }
+  }, [aiOverlays, symbol, variant, t, showMacd, showRsi, compact]);
 
   useEffect(() => {
     if (skipDataEffectRef.current) {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -385,6 +385,10 @@ export const api = {
     if (before) params.set("before", before);
     return request<KlineChart>(`/market/kline?${params.toString()}`);
   },
+  chartOverlays: (symbol: string) =>
+    request<ChartOverlaySet>(
+      `/market/overlays?symbol=${encodeURIComponent(symbol)}`,
+    ),
   listReports: () => request<ResearchReportListItem[]>("/research/reports"),
   downloadReportMarkdown: (id: number) => {
     window.open(
@@ -633,7 +637,8 @@ export interface Card {
     | "plan"
     | "financial"
     | "stock_choice"
-    | "route_choice";
+    | "route_choice"
+    | "chart_overlays";
   data: Record<string, unknown>;
 }
 
@@ -1434,6 +1439,30 @@ export interface ActionSignal {
 export interface DailyActionCenter {
   signals: ActionSignal[];
   summary: string;
+}
+
+export interface ChartOverlayPoint {
+  time: string;
+  price: number;
+}
+
+export interface ChartOverlay {
+  id: string;
+  kind: "trend" | "level";
+  a?: ChartOverlayPoint;
+  b?: ChartOverlayPoint;
+  side?: "support" | "resistance";
+  price?: number;
+  strength: number;
+  touches?: number;
+  source: "algo" | "ai";
+  rationale?: string;
+}
+
+export interface ChartOverlaySet {
+  symbol: string;
+  generatedAt: string;
+  overlays: ChartOverlay[];
 }
 
 export interface KlineChart {

--- a/web/src/chartOverlayBus.ts
+++ b/web/src/chartOverlayBus.ts
@@ -1,0 +1,23 @@
+/**
+ * Tiny pub/sub channel for Copilot chart overlays (Phase 9b):
+ * the chat card publishes an AI ChartOverlaySet, the focused StockChart
+ * subscribes and renders it through the same line-series path as the
+ * local auto trendlines.
+ */
+
+import type { ChartOverlaySet } from "./api";
+
+type Listener = (set: ChartOverlaySet | null) => void;
+
+const listeners = new Set<Listener>();
+
+export function publishChartOverlays(set: ChartOverlaySet | null): void {
+  for (const listener of listeners) listener(set);
+}
+
+export function subscribeChartOverlays(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/web/src/locales/en.ts
+++ b/web/src/locales/en.ts
@@ -33,6 +33,15 @@ export const en: Dict = {
     priceConflictBody:
       "{count} symbol(s) show >1% Sina/AkShare spread ({preview}) — may be delay or methodology.",
   },
+  overlays: {
+    title: "AI Trendlines",
+    lines: "lines",
+    showOnChart: "Show on chart",
+    applied: "Shown on chart",
+    none: "No significant support/resistance lines detected recently.",
+    support: "Support",
+    resistance: "Resistance",
+  },
   lists: {
     aria: "Lists sidebar",
     expand: "Expand lists",

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -33,6 +33,15 @@ export const zh: Dict = {
     priceConflictBody:
       "{count} 只标的新浪/AkShare 价差 >1%（{preview}），可能由延迟或口径差异导致。",
   },
+  overlays: {
+    title: "AI 趋势线",
+    lines: "条线",
+    showOnChart: "在图表显示",
+    applied: "已显示在图表",
+    none: "近期走势未识别出显著支撑/压力线。",
+    support: "支撑",
+    resistance: "压力",
+  },
   lists: {
     aria: "列表侧栏",
     expand: "展开列表",

--- a/web/src/styles/app/overlays.css
+++ b/web/src/styles/app/overlays.css
@@ -1333,3 +1333,20 @@
 .price-conflict-banner strong {
   color: #b8860b;
 }
+
+.chart-overlays-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 8px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.chart-overlays-list li {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  font-size: 12px;
+  line-height: 1.5;
+}


### PR DESCRIPTION
ChartOverlaySet schema + Python 趋势线算法（移植 chartTrendlines.ts）+ GET /market/overlays + skill_chart_overlays 技能；Copilot 对话卡片可一键将 AI 画线渲染到焦点图表（source='ai'，复用 9a 渲染路径）。