### PR TITLE
test(data): fix flaky global markets mock test

### DIFF
--- a/tests/data/test_global_markets.py
+++ b/tests/data/test_global_markets.py
@@ -43,9 +43,14 @@ def test_parse_skips_malformed_lines() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_indices_mock_mode() -> None:
-    # 测试环境 USE_MOCK_MARKET_DATA=true — 返回固定 mock 数据
+async def test_get_indices_mock_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    # 目录级 conftest 会全局关闭 mock；本用例显式打开，不依赖执行顺序。
+    monkeypatch.setenv("USE_MOCK_MARKET_DATA", "true")
+    from stockresearch.core.config import get_settings
+
+    get_settings.cache_clear()
     rows = await GlobalMarketsProvider().get_indices()
+    get_settings.cache_clear()
     assert len(rows) == 5
     assert any(row.name == "恒生指数" for row in rows)
 


### PR DESCRIPTION
tests/data/conftest.py 的 autouse fixture 会全局关闭 USE_MOCK_MARKET_DATA，导致 test_get_indices_mock_mode 实际走真实网络路径：本地新浪可达时恰好返回 5 条而过，CI 网络受限超时时返回空列表而失败（PR #26 首次 backend run 即此原因）。修复：该用例内显式开启 mock 并清理 settings 缓存，不再依赖执行顺序与外网。