### PR TITLE
fix: 全量代码审计问题修复（安全/可靠性/前端健壮性）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ docs/*
 !docs/PRD.md
 !docs/screenshots/
 !docs/screenshots/**/*.png
+
+# local-only
+.qoder-cn/
+StockResearch-*-src.zip

--- a/src/stockresearch/agents/financial/agent.py
+++ b/src/stockresearch/agents/financial/agent.py
@@ -1,5 +1,6 @@
 """Financial ratio analysis agent — PE/PB/ROE/margins/trends for A-share stocks."""
 
+import asyncio
 import json
 import logging
 from typing import Any
@@ -95,7 +96,7 @@ class FinancialRatioAgent:
         """Fetch financial data from AkShare (stock_financial_abstract_ths)."""
         cache_key = f"financial:abstract_ths:{symbol}"
         ttl = provider_ttl("akshare_financials")
-        cached = get_sqlite_cached(cache_key)
+        cached = await asyncio.to_thread(get_sqlite_cached, cache_key)
         if cached is not None:
             data = json.loads(json.dumps(cached))
             try:
@@ -154,7 +155,9 @@ class FinancialRatioAgent:
         try:
             import akshare as ak
 
-            df = ak.stock_financial_abstract_ths(symbol=symbol, indicator="按年度")
+            df = await asyncio.to_thread(
+                ak.stock_financial_abstract_ths, symbol=symbol, indicator="按年度"
+            )
             if df is None or df.empty:
                 logger.warning("No financial data returned for %s", symbol)
                 return data
@@ -259,7 +262,7 @@ class FinancialRatioAgent:
             logger.warning("Financial data fetch failed for %s: %s", symbol, exc)
 
         if data.get("roe") is not None or data.get("eps") is not None:
-            set_sqlite_cached(cache_key, json.loads(json.dumps(data)), ttl)
+            await asyncio.to_thread(set_sqlite_cached, cache_key, json.loads(json.dumps(data)), ttl)
         return data
 
     def _compute_ratios(self, raw: dict[str, Any], symbol: str, name: str) -> list[dict[str, str]]:

--- a/src/stockresearch/agents/industry/stream.py
+++ b/src/stockresearch/agents/industry/stream.py
@@ -184,7 +184,7 @@ async def run_industry_research_stream(
     if with_debate:
         situation = summarize_situation(dimensions)
         leader_note = "\n".join(f"- {ld.name}: {ld.brief}" for ld in leader_briefs)
-        debate_context = f"板块：{sector}\n作战情：\n{situation}\n龙头简评：\n{leader_note}"
+        debate_context = f"板块：{sector}\n作战情报：\n{situation}\n龙头简评：\n{leader_note}"
         yield status_event("status.industry.battle_start")
         async for event in iter_battle_events(
             client,

--- a/src/stockresearch/agents/market/research_stream.py
+++ b/src/stockresearch/agents/market/research_stream.py
@@ -136,7 +136,7 @@ async def run_market_research_stream(
     yield status_event("status.market.research.battle_start")
 
     enrichment = format_enrichment_block(ctx.global_text, ctx.macro_text)
-    debate_context = f"{MARKET_NAME}\n用户关切：{query}\n作战情摘要：\n{situation}"
+    debate_context = f"{MARKET_NAME}\n用户关切：{query}\n作战情报摘要：\n{situation}"
     if enrichment:
         debate_context += f"\n\n{enrichment}"
     debate: DebateResult | None = None

--- a/src/stockresearch/agents/orchestrator/chat_execute.py
+++ b/src/stockresearch/agents/orchestrator/chat_execute.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 
@@ -25,6 +26,8 @@ from stockresearch.db.models import Holding
 from stockresearch.services.chat.scope import ChatContextScope, build_chat_context_scope
 
 ProgressCallback = Callable[[dict[str, object]], Awaitable[None]]
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -218,12 +221,24 @@ async def _run_plan_execute_sync(ctx: ChatRunContext) -> ChatExecuteResult:
     if ctx.on_progress:
         agent.set_progress_callback(ctx.on_progress)
 
-    reply, plan_cards = await agent.run(
-        ctx.message,
-        history=ctx.history,
-        long_term_context=ctx.long_term_context,
-        user_context_text=ctx.user_context_text,
-    )
+    try:
+        reply, plan_cards = await asyncio.wait_for(
+            agent.run(
+                ctx.message,
+                history=ctx.history,
+                long_term_context=ctx.long_term_context,
+                user_context_text=ctx.user_context_text,
+            ),
+            timeout=get_settings().agent_timeout_seconds,
+        )
+    except TimeoutError:
+        logger.warning(
+            "plan-execute turn timed out after %ss", get_settings().agent_timeout_seconds
+        )
+        return ChatExecuteResult(
+            reply="分析耗时较长已超时，请您稍后重试，或把问题描述得更具体一些。",
+            partial=True,
+        )
     merged = merge_plan_cards(plan_cards, react_agent.tool_cards())
     return ChatExecuteResult(reply=reply, cards=merged, intent=_intent_from_cards(merged))
 
@@ -254,12 +269,22 @@ async def _run_react_sync(ctx: ChatRunContext) -> ChatExecuteResult:
                 on_progress=ctx.on_progress,
             )
 
-    reply, cards = await agent.run(
-        run_message,
-        history=ctx.history,
-        long_term_context=ctx.long_term_context,
-        user_context_text=ctx.user_context_text,
-    )
+    try:
+        reply, cards = await asyncio.wait_for(
+            agent.run(
+                run_message,
+                history=ctx.history,
+                long_term_context=ctx.long_term_context,
+                user_context_text=ctx.user_context_text,
+            ),
+            timeout=get_settings().agent_timeout_seconds,
+        )
+    except TimeoutError:
+        logger.warning("react turn timed out after %ss", get_settings().agent_timeout_seconds)
+        return ChatExecuteResult(
+            reply="分析耗时较长已超时，请您稍后重试，或把问题描述得更具体一些。",
+            partial=True,
+        )
     return ChatExecuteResult(reply=reply, cards=cards, intent=_intent_from_cards(cards))
 
 

--- a/src/stockresearch/agents/orchestrator/plan_execute.py
+++ b/src/stockresearch/agents/orchestrator/plan_execute.py
@@ -51,9 +51,9 @@ _PLAN_SYSTEM = """你是「StockResearch」的研究规划 Agent。用户提出�
 - **禁止只规划 1 个数据步骤**；金融问题至少 3 步，最后一步用 tool:auto 做归纳分析
 - 步骤不超过 5 步；顺序：先行情/数据 → 再新闻或持仓/板块 → 最后解读研判
 - 大盘/市场走势类至少：get_market_data → get_news → auto 综合解读
-- 个股类至少：get_stock_quote 或 get_stock_research → get_news → auto 解读
+- 个股类至少：get_stock_quote 或 skill_stock_research → get_news → auto 解读
 - 对比多只标的：分别拉数据/投研 → get_news → auto 对比结论
-- 如果涉及个股深度投研，可用 debate_stock
+- 如果涉及个股深度投研，可用 skill_bull_bear_debate
 - 不要建议买卖"""
 
 _EXECUTE_SYSTEM = """你是「StockResearch」的执行 Agent。根据计划步骤执行研究任务。
@@ -148,40 +148,41 @@ def _normalize_plan_steps(query: str, steps: list[dict[str, Any]]) -> list[dict[
 
     if is_stock_comparison(msg) and count_stock_mentions(msg) >= 2:
         codes = list(dict.fromkeys(STOCK_CODE_RE.findall(msg)))
-        if len(codes) < 2:
-            codes = ["600519", "000858"]
-        return _reindex_steps(
-            [
-                {
-                    "id": 1,
-                    "description": f"获取 {codes[0]} 多维投研",
-                    "tool": "skill_stock_research",
-                    "args": {"symbol": codes[0]},
-                },
-                {
-                    "id": 2,
-                    "description": f"获取 {codes[1]} 多维投研",
-                    "tool": "skill_stock_research",
-                    "args": {"symbol": codes[1]},
-                },
-                {
-                    "id": 3,
-                    "description": "获取相关市场快讯与行业背景",
-                    "tool": "get_news",
-                    "args": {},
-                },
-                {
-                    "id": 4,
-                    "description": "对比两只标的的估值、趋势与风险差异",
-                    "tool": "auto",
-                    "args": {},
-                },
-            ]
-        )
+        if len(codes) >= 2:
+            return _reindex_steps(
+                [
+                    {
+                        "id": 1,
+                        "description": f"获取 {codes[0]} 多维投研",
+                        "tool": "skill_stock_research",
+                        "args": {"symbol": codes[0]},
+                    },
+                    {
+                        "id": 2,
+                        "description": f"获取 {codes[1]} 多维投研",
+                        "tool": "skill_stock_research",
+                        "args": {"symbol": codes[1]},
+                    },
+                    {
+                        "id": 3,
+                        "description": "获取相关市场快讯与行业背景",
+                        "tool": "get_news",
+                        "args": {},
+                    },
+                    {
+                        "id": 4,
+                        "description": "对比两只标的的估值、趋势与风险差异",
+                        "tool": "auto",
+                        "args": {},
+                    },
+                ]
+            )
+        # Fewer than two explicit stock codes — do not fabricate symbols; fall
+        # through to generic padding so we never analyze the wrong stocks.
 
     symbol = _extract_symbol(msg)
-    if has_stock_reference(msg) or symbol:
-        sym = symbol or "600519"
+    if symbol:
+        sym = symbol
         from stockresearch.agents.research.budget import parse_depth_from_text
 
         depth_cue = parse_depth_from_text(msg)

--- a/src/stockresearch/agents/orchestrator/stream.py
+++ b/src/stockresearch/agents/orchestrator/stream.py
@@ -221,7 +221,9 @@ async def _run_chat_stream_body(
             )
         except Exception as exc:
             logger.exception("Chat stream turn failed: %s", exc)
-            reply = f"分析过程出错（{type(exc).__name__}），请稍后重试。详细错误已记录到服务端日志。"
+            reply = (
+                f"分析过程出错（{type(exc).__name__}），请稍后重试。详细错误已记录到服务端日志。"
+            )
             partial = True
             await on_progress(
                 {
@@ -235,35 +237,46 @@ async def _run_chat_stream_body(
 
     turn_task = asyncio.create_task(_run_turn())
 
-    while True:
-        hint = await progress_queue.get()
-        if hint is None:
-            break
-        yield hint
-        if hint.get("type") == "skill_start":
-            save_checkpoint(
-                db,
-                user_id,
-                sid,
-                {
-                    "mode": "skill",
-                    "skill_id": hint.get("skill_id"),
-                    "skill_run_id": hint.get("skill_run_id"),
-                },
-            )
-        elif hint.get("message_key"):
-            save_checkpoint(
-                db,
-                user_id,
-                sid,
-                {
-                    "mode": "react",
-                    "message_key": hint.get("message_key"),
-                    "message_params": hint.get("message_params"),
-                },
-            )
+    try:
+        while True:
+            hint = await progress_queue.get()
+            if hint is None:
+                break
+            yield hint
+            if hint.get("type") == "skill_start":
+                save_checkpoint(
+                    db,
+                    user_id,
+                    sid,
+                    {
+                        "mode": "skill",
+                        "skill_id": hint.get("skill_id"),
+                        "skill_run_id": hint.get("skill_run_id"),
+                    },
+                )
+            elif hint.get("message_key"):
+                save_checkpoint(
+                    db,
+                    user_id,
+                    sid,
+                    {
+                        "mode": "react",
+                        "message_key": hint.get("message_key"),
+                        "message_params": hint.get("message_params"),
+                    },
+                )
 
-    await turn_task
+        await turn_task
+    finally:
+        # If the client disconnects the async generator is closed mid-loop;
+        # cancel the background turn so it stops calling the LLM and touching
+        # the request-scoped DB session.
+        if not turn_task.done():
+            turn_task.cancel()
+            try:
+                await turn_task
+            except (asyncio.CancelledError, Exception):
+                pass
 
     yield {
         "type": "done",

--- a/src/stockresearch/agents/research/debate.py
+++ b/src/stockresearch/agents/research/debate.py
@@ -108,7 +108,7 @@ def _bull_prompt(context: str, round_num: int, transcript: list[str], side_label
     if round_num == 1:
         return f"{context}\n第1轮：{theme}"
     history = "\n".join(transcript)
-    return f"{context}\n" f"此前交锋：\n{history}\n" f"第{round_num}轮：{theme}"
+    return f"{context}\n此前交锋：\n{history}\n第{round_num}轮：{theme}"
 
 
 def _bear_prompt(
@@ -122,10 +122,7 @@ def _bear_prompt(
     prefix = f"此前：\n{history}\n" if history else ""
     theme = _round_theme(round_num, bullish=False)
     return (
-        f"{context}\n"
-        f"第{round_num}轮{side_label}刚说：{bull_text}\n"
-        f"{prefix}"
-        f"第{round_num}轮：{theme}"
+        f"{context}\n第{round_num}轮{side_label}刚说：{bull_text}\n{prefix}第{round_num}轮：{theme}"
     )
 
 
@@ -221,7 +218,7 @@ async def iter_battle_vote_events(
 
 
 _RESEARCH_MANAGER_SYSTEM = f"""你是 Research Manager（投研负责人）。{JUDGE_VOICE}
-阅读作战情摘要、辩论记录与投票结果，只输出 JSON，禁止 markdown。
+阅读作战情报摘要、辩论记录与投票结果，只输出 JSON，禁止 markdown。
 {{"investment_thesis":"投资要点2-3句","key_risk":"最大风险1-2句","debate_summary":"辩论核心1-2句","recommended_bias":"偏多|偏空|中性"}}
 不要建议买卖。"""
 
@@ -242,7 +239,7 @@ async def iter_research_manager_events(
         "agent_name": "Research Manager",
         "role": "manager",
     }
-    user = f"作战情摘要：\n{situation}\n\n辩论：\n{debate_transcript}\n\n{vote_summary}"
+    user = f"作战情报摘要：\n{situation}\n\n辩论：\n{debate_transcript}\n\n{vote_summary}"
     thesis = ""
     async for event in iter_llm_stream_events(
         stream_id="research_manager",
@@ -516,9 +513,14 @@ def _infer_bias(
     dimensions: dict[str, DimensionResult],
 ) -> Literal["bullish", "bearish", "neutral"]:
     text = judge_text.lower()
-    if "偏多" in judge_text or "bullish" in text or "看多" in judge_text:
+    has_bull = "偏多" in judge_text or "bullish" in text or "看多" in judge_text
+    has_bear = "偏空" in judge_text or "bearish" in text or "看空" in judge_text
+    # When both directions appear (common in balanced verdicts such as
+    # "空方强调估值压力，但…") keyword presence is ambiguous — defer to scores
+    # instead of defaulting to bullish.
+    if has_bull and not has_bear:
         return "bullish"
-    if "偏空" in judge_text or "bearish" in text or "看空" in judge_text:
+    if has_bear and not has_bull:
         return "bearish"
     scores = [d.score for d in dimensions.values()]
     avg = sum(scores) / len(scores) if scores else 5.0

--- a/src/stockresearch/agents/research/stream.py
+++ b/src/stockresearch/agents/research/stream.py
@@ -248,7 +248,7 @@ async def run_research_stream(
     situation = summarize_situation(dimensions)
     yield status_event("status.research.battle_start")
 
-    debate_context = f"{name}({symbol})\n作战情摘要：\n{situation}"
+    debate_context = f"{name}({symbol})\n作战情报摘要：\n{situation}"
     debate: DebateResult | None = None
     async for event in iter_battle_events(
         client,

--- a/src/stockresearch/agents/risk/stream.py
+++ b/src/stockresearch/agents/risk/stream.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 from collections.abc import AsyncIterator
+from datetime import UTC, datetime
 from typing import Any
 
 from stockresearch.agents.master_commentary.context import build_risk_context
@@ -52,6 +53,7 @@ from stockresearch.core.schemas import (
     VaRResultOut,
 )
 from stockresearch.data.providers.market import QuoteProvider
+from stockresearch.data.providers.market.common import Quote
 from stockresearch.db.models import Holding
 from stockresearch.i18n.status_events import status_event
 from stockresearch.services.compliance_language import (
@@ -195,9 +197,27 @@ async def run_risk_checkup_stream(
     }
     quote_provider = QuoteProvider()
     quote_map = await quote_provider.get_quotes([h.symbol for h in holdings]) if holdings else {}
-    quotes = [quote_map[h.symbol] for h in holdings if h.symbol in quote_map]
-    if holdings and len(quotes) != len(holdings):
-        missing = [h.symbol for h in holdings if h.symbol not in quote_map]
+    quotes: list[Quote] = []
+    missing: list[str] = []
+    for h in holdings:
+        q = quote_map.get(h.symbol)
+        if q is None:
+            missing.append(h.symbol)
+            # Placeholder keeps holdings/quotes aligned so downstream zip never
+            # crashes when a quote provider is temporarily unavailable.
+            q = Quote(
+                symbol=h.symbol,
+                name=h.name or h.symbol,
+                price=float(h.float_cost_price or 0.0),
+                change_pct=0.0,
+                open=0.0,
+                high=0.0,
+                low=0.0,
+                volume=0.0,
+                updated_at=datetime.now(UTC),
+            )
+        quotes.append(q)
+    if missing:
         logger.warning("Risk checkup missing quotes for: %s", ",".join(missing))
 
     alerts = _parse_rule_alerts(holdings, quotes)

--- a/src/stockresearch/agents/stream_typewriter.py
+++ b/src/stockresearch/agents/stream_typewriter.py
@@ -93,21 +93,42 @@ async def pump_llm_stream_events_to_queue(
     system: str,
     user: str,
 ) -> str:
-    """Stream LLM tokens into queue as text_delta + agent_done."""
+    """Stream LLM tokens into queue as text_delta + agent_done.
+
+    Guarantees a ``_PUMP_DONE`` sentinel is emitted even when the underlying
+    LLM stream raises, so the merged iterator never hangs.
+    """
     content = ""
-    async for event in iter_llm_stream_events(
-        stream_id=stream_id,
-        agent_id=agent_id,
-        agent_name=agent_name,
-        role=role,
-        llm=llm,
-        system=system,
-        user=user,
-    ):
-        await queue.put(event)
-        if event.get("type") == "agent_done":
-            content = str(event.get("content", ""))
-    await queue.put(_PUMP_DONE)
+    done_emitted = False
+    try:
+        async for event in iter_llm_stream_events(
+            stream_id=stream_id,
+            agent_id=agent_id,
+            agent_name=agent_name,
+            role=role,
+            llm=llm,
+            system=system,
+            user=user,
+        ):
+            await queue.put(event)
+            if event.get("type") == "agent_done":
+                content = str(event.get("content", ""))
+                done_emitted = True
+    except Exception as exc:
+        logger.warning("LLM stream pump failed for agent %s: %s", agent_id, exc)
+        if not done_emitted:
+            content = content or f"{agent_name}输出中断，请稍后重试。"
+            await queue.put(
+                {
+                    "type": "agent_done",
+                    "agent_id": agent_id,
+                    "agent_name": agent_name,
+                    "role": role,
+                    "content": content,
+                }
+            )
+    finally:
+        await queue.put(_PUMP_DONE)
     return content
 
 
@@ -131,13 +152,8 @@ async def pump_dimension_llm_stream(
         }
     )
     await queue.put(status_event("status.research.fetch_data", agent=agent_name))
-    try:
-        system, user, data = await asyncio.wait_for(
-            prepare(ctx),  # type: ignore[operator]
-            timeout=_PREPARE_TIMEOUT_SEC,
-        )
-    except Exception as exc:
-        logger.warning("Dimension %s prepare failed: %s", agent_id, exc)
+
+    async def _emit_unavailable() -> None:
         content = f"{agent_name}数据暂不可用，请稍后重试。"
         dim = DimensionResult(
             agent=agent_id,
@@ -167,48 +183,61 @@ async def pump_dimension_llm_stream(
                 "content": content,
             }
         )
-        await queue.put(_PUMP_DONE)
-        return
 
-    parts: list[str] = []
-    async for chunk in ctx.llm.stream_complete(system, user):  # type: ignore[attr-defined]
-        parts.append(chunk)
+    try:
+        try:
+            system, user, data = await asyncio.wait_for(
+                prepare(ctx),  # type: ignore[operator]
+                timeout=_PREPARE_TIMEOUT_SEC,
+            )
+        except Exception as exc:
+            logger.warning("Dimension %s prepare failed: %s", agent_id, exc)
+            await _emit_unavailable()
+            return
+
+        parts: list[str] = []
+        async for chunk in ctx.llm.stream_complete(system, user):  # type: ignore[attr-defined]
+            parts.append(chunk)
+            await queue.put(
+                {
+                    "type": "text_delta",
+                    "stream_id": agent_id,
+                    "agent_id": agent_id,
+                    "agent_name": agent_name,
+                    "role": "analyst",
+                    "delta": chunk,
+                }
+            )
+        from stockresearch.utils.disclaimer import strip_disclaimer
+
+        analysis = strip_disclaimer("".join(parts))
+        dim = build(data, analysis)  # type: ignore[operator]
+        dimensions[agent_id] = dim
+        content = analysis.strip() or analysis
         await queue.put(
             {
-                "type": "text_delta",
-                "stream_id": agent_id,
+                "type": "dimension_ready",
                 "agent_id": agent_id,
                 "agent_name": agent_name,
                 "role": "analyst",
-                "delta": chunk,
+                "content": content,
+                "dimension": dim.model_dump(mode="json"),  # type: ignore[union-attr]
             }
         )
-    from stockresearch.utils.disclaimer import strip_disclaimer
-
-    analysis = strip_disclaimer("".join(parts))
-    dim = build(data, analysis)  # type: ignore[operator]
-    dimensions[agent_id] = dim
-    content = analysis.strip() or analysis
-    await queue.put(
-        {
-            "type": "dimension_ready",
-            "agent_id": agent_id,
-            "agent_name": agent_name,
-            "role": "analyst",
-            "content": content,
-            "dimension": dim.model_dump(mode="json"),  # type: ignore[union-attr]
-        }
-    )
-    await queue.put(
-        {
-            "type": "agent_done",
-            "agent_id": agent_id,
-            "agent_name": agent_name,
-            "role": "analyst",
-            "content": content,
-        }
-    )
-    await queue.put(_PUMP_DONE)
+        await queue.put(
+            {
+                "type": "agent_done",
+                "agent_id": agent_id,
+                "agent_name": agent_name,
+                "role": "analyst",
+                "content": content,
+            }
+        )
+    except Exception as exc:
+        logger.warning("Dimension %s stream/build failed: %s", agent_id, exc)
+        await _emit_unavailable()
+    finally:
+        await queue.put(_PUMP_DONE)
 
 
 async def iter_agent_done_stream(
@@ -286,7 +315,13 @@ async def iter_merged_agent_streams_from_tasks(
     pumps: list[asyncio.Task[None]] = []
 
     async def when_ready(task: asyncio.Task[AgentStreamItem]) -> None:
-        item = await task
+        try:
+            item = await task
+        except Exception:
+            logger.warning("Merged agent stream task failed", exc_info=True)
+            # Still emit a done marker so the merged iterator terminates.
+            await queue.put(_PUMP_DONE)
+            return
         await pump_agent_done_stream(
             queue,
             agent_id=item.agent_id,

--- a/src/stockresearch/agents/structured_output.py
+++ b/src/stockresearch/agents/structured_output.py
@@ -25,13 +25,13 @@ def extract_json_dict(raw: str) -> dict[str, object] | None:
 
 def _normalize_bias(text: str) -> Literal["偏多", "偏空", "中性"]:
     lowered = text.lower()
-    if "偏多" in text or "bullish" in lowered or "看多" in text:
+    has_bull = "偏多" in text or "bullish" in lowered or "看多" in text
+    has_bear = "偏空" in text or "bearish" in lowered or "看空" in text
+    # Both directions present => ambiguous; do not default to bullish.
+    if has_bull and not has_bear:
         return "偏多"
-    if "偏空" in text or "bearish" in lowered or "看空" in text:
+    if has_bear and not has_bull:
         return "偏空"
-    for token in _BIAS_TOKENS:
-        if token in text:
-            return token  # type: ignore[return-value]
     return "中性"
 
 

--- a/src/stockresearch/api/routes/market.py
+++ b/src/stockresearch/api/routes/market.py
@@ -59,6 +59,8 @@ async def stock_quotes(
     db: Session = Depends(get_db),
 ) -> list[StockQuoteOut]:
     symbol_list = list(dict.fromkeys(s.strip() for s in symbols.split(",") if s.strip()))
+    if len(symbol_list) > 100:
+        raise HTTPException(status_code=400, detail="单次最多查询 100 个标的")
     if not symbol_list:
         holdings = db.query(Holding).filter(Holding.user_id == user.id).all()
         symbol_list = list(dict.fromkeys(h.symbol for h in holdings))

--- a/src/stockresearch/core/llm_config.py
+++ b/src/stockresearch/core/llm_config.py
@@ -26,6 +26,11 @@ class LlmOverrides:
     def effective_api_key(self) -> str:
         if self.api_key and self.api_key.strip():
             return self.api_key.strip()
+        # Security: never fall back to the server-side key when a custom
+        # base_url is overridden — that would send the server credential to a
+        # third-party host. A custom endpoint must bring its own key.
+        if self.base_url and self.base_url.strip():
+            return ""
         return get_settings().llm_api_key
 
     def effective_base_url(self) -> str:

--- a/src/stockresearch/data/providers/kimi_cli.py
+++ b/src/stockresearch/data/providers/kimi_cli.py
@@ -11,6 +11,7 @@ import json
 import logging
 import shutil
 from dataclasses import dataclass
+from datetime import date
 
 from stockresearch.core.config import get_settings
 
@@ -33,6 +34,10 @@ class KimiCliParseError(KimiCliError):
     """CLI 输出无法解析为 JSON。"""
 
 
+class KimiCliQuotaExceededError(KimiCliError):
+    """当日调用次数超过 kimi_live_max_calls_per_day 配额。"""
+
+
 @dataclass(frozen=True)
 class KimiCliResult:
     payload: dict[str, object]
@@ -42,6 +47,25 @@ class KimiCliResult:
 _JSON_INSTRUCTION = (
     "请只输出一个 JSON 对象作为回答,不要输出任何其他文字、解释或 markdown 代码块标记。"
 )
+
+# Module-level daily quota counter shared by all KimiCliClient instances.
+_quota_date: date | None = None
+_quota_count = 0
+
+
+def _consume_daily_quota() -> None:
+    """按自然日计数;超额时拒绝调用,防止烧穿 Kimi Code 会员配额。"""
+    global _quota_date, _quota_count
+    limit = get_settings().kimi_live_max_calls_per_day
+    today = date.today()
+    if _quota_date != today:
+        _quota_date = today
+        _quota_count = 0
+    if limit > 0 and _quota_count >= limit:
+        raise KimiCliQuotaExceededError(
+            f"kimi CLI 当日调用已达上限({limit} 次),请明日再试或调高配额"
+        )
+    _quota_count += 1
 
 
 def _extract_assistant_text(stream_output: str) -> str:
@@ -96,6 +120,7 @@ class KimiCliClient:
     async def query_json(self, prompt: str, *, max_retries: int = 2) -> KimiCliResult:
         if not self.available():
             raise KimiCliNotAvailableError(f"kimi CLI 不可用: {self._cli_path}")
+        _consume_daily_quota()
         full_prompt = f"{prompt}\n\n{_JSON_INSTRUCTION}"
         last_exc: KimiCliError | None = None
         for attempt in range(max_retries + 1):

--- a/src/stockresearch/db/session.py
+++ b/src/stockresearch/db/session.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable, Generator
 from pathlib import Path
 
-from sqlalchemy import create_engine, inspect, text
+from sqlalchemy import create_engine, event, inspect, text
 from sqlalchemy.engine import Connection
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import NullPool, StaticPool
@@ -23,7 +23,9 @@ def _resolve_database_url(url: str) -> str:
 
 _settings = get_settings()
 _db_url = _resolve_database_url(_settings.database_url)
-_connect_args = {"check_same_thread": False} if _db_url.startswith("sqlite") else {}
+# `timeout` lets concurrent writers (API + scheduler worker) wait instead of
+# immediately raising "database is locked".
+_connect_args = {"check_same_thread": False, "timeout": 30} if _db_url.startswith("sqlite") else {}
 
 if _db_url == "sqlite://":
     # 内存数据库（测试）：必须共享同一连接，否则每次连接都是新的空库。
@@ -38,6 +40,18 @@ else:
         max_overflow=20,
         pool_timeout=30,
     )
+
+if _db_url.startswith("sqlite") and _db_url != "sqlite://":
+
+    @event.listens_for(engine, "connect")
+    def _enable_sqlite_wal(dbapi_connection, connection_record):  # pragma: no cover
+        # WAL allows a reader and a writer to proceed concurrently, which the
+        # API + worker double-process setup relies on.
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.execute("PRAGMA busy_timeout=30000")
+        cursor.close()
+
 
 SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
 
@@ -68,10 +82,7 @@ def _migration_002_user_preferences(conn: Connection) -> None:
         )
     )
     conn.execute(
-        text(
-            "CREATE INDEX IF NOT EXISTS ix_user_preferences_user_id "
-            "ON user_preferences (user_id)"
-        )
+        text("CREATE INDEX IF NOT EXISTS ix_user_preferences_user_id ON user_preferences (user_id)")
     )
 
 
@@ -88,8 +99,7 @@ def _migration_003_provider_cache(conn: Connection) -> None:
     )
     conn.execute(
         text(
-            "CREATE INDEX IF NOT EXISTS ix_provider_cache_expires_at "
-            "ON provider_cache (expires_at)"
+            "CREATE INDEX IF NOT EXISTS ix_provider_cache_expires_at ON provider_cache (expires_at)"
         )
     )
 
@@ -123,7 +133,7 @@ def _migrate_sqlite_schema() -> None:
                 continue
             migration(conn)
             conn.execute(
-                text("INSERT INTO schema_migrations(version, name) " "VALUES (:version, :name)"),
+                text("INSERT INTO schema_migrations(version, name) VALUES (:version, :name)"),
                 {"version": version, "name": name},
             )
 

--- a/src/stockresearch/main.py
+++ b/src/stockresearch/main.py
@@ -32,7 +32,11 @@ def main(argv: list[str] | None = None) -> int:
     subparsers = parser.add_subparsers(dest="command")
 
     api_parser = subparsers.add_parser("api", help="Run the FastAPI server")
-    api_parser.add_argument("--host", default="0.0.0.0", help="Bind host")
+    api_parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Bind host (defaults to localhost; pass 0.0.0.0 only behind a trusted reverse proxy)",
+    )
     api_parser.add_argument("--port", type=int, default=8000, help="Bind port")
     api_parser.add_argument("--reload", action="store_true", help="Enable auto-reload")
 

--- a/src/stockresearch/services/env_file.py
+++ b/src/stockresearch/services/env_file.py
@@ -8,6 +8,15 @@ from pathlib import Path
 _ENV_KEY_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
 
 
+def _sanitize_value(value: str) -> str:
+    """Strip CR/LF and other control chars so a value cannot inject new keys.
+
+    Prevents newline-injection (e.g. ``base_url="https://x\\nEVIL=1"``) that
+    would otherwise append arbitrary variables to the .env file.
+    """
+    return "".join(ch for ch in value if ch.isprintable()).strip()
+
+
 def resolve_env_path() -> Path:
     """Return .env path in the current working directory (project root when started locally)."""
     return Path.cwd() / ".env"
@@ -39,7 +48,7 @@ def write_env_vars(updates: dict[str, str], path: Path | None = None) -> Path:
         if example.is_file():
             lines = example.read_text(encoding="utf-8").splitlines()
 
-    pending = dict(updates)
+    pending = {key: _sanitize_value(value) for key, value in updates.items()}
     out: list[str] = []
     for line in lines:
         stripped = line.strip()

--- a/src/stockresearch/utils/llm.py
+++ b/src/stockresearch/utils/llm.py
@@ -1,5 +1,6 @@
 """LLM client with mock fallback for tests."""
 
+import asyncio
 import json
 import logging
 from abc import ABC, abstractmethod
@@ -30,6 +31,19 @@ def _httpx_client_kwargs() -> dict:
     if proxy:
         kwargs["proxy"] = proxy
     return kwargs
+
+
+# Transient failures worth retrying: rate limits, server errors, timeouts.
+_RETRYABLE_STATUS = {408, 425, 429, 500, 502, 503, 504}
+_MAX_LLM_RETRIES = 2
+
+
+def _is_retryable_llm_error(exc: Exception) -> bool:
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code in _RETRYABLE_STATUS
+    return isinstance(
+        exc, httpx.ConnectError | httpx.ConnectTimeout | httpx.ReadTimeout | httpx.PoolTimeout
+    )
 
 
 def _styled_system(system: str) -> str:
@@ -65,6 +79,30 @@ class OpenAICompatibleClient(LLMClient):
         self._base_url = resolve_chat_completions_url(cfg.effective_base_url())
         self._model = cfg.effective_model()
         self._temperature = cfg.effective_temperature()
+
+    async def _post_with_retry(
+        self, headers: dict[str, str], payload: dict[str, object]
+    ) -> dict[str, object]:
+        """POST a chat-completion request, retrying on transient failures."""
+        for attempt in range(_MAX_LLM_RETRIES + 1):
+            try:
+                async with httpx.AsyncClient(**_httpx_client_kwargs()) as client:
+                    resp = await client.post(self._base_url, headers=headers, json=payload)
+                    resp.raise_for_status()
+                    return resp.json()  # type: ignore[no-any-return]
+            except Exception as exc:
+                if not _is_retryable_llm_error(exc) or attempt >= _MAX_LLM_RETRIES:
+                    raise
+                backoff = 0.5 * (2**attempt)
+                logger.warning(
+                    "LLM request failed (attempt %d/%d), retrying in %.1fs: %s",
+                    attempt + 1,
+                    _MAX_LLM_RETRIES + 1,
+                    backoff,
+                    exc,
+                )
+                await asyncio.sleep(backoff)
+        raise RuntimeError("unreachable")  # pragma: no cover
 
     async def stream_complete(self, system: str, user: str) -> AsyncIterator[str]:
         system = _styled_system(system)
@@ -161,31 +199,24 @@ class OpenAICompatibleClient(LLMClient):
             "messages": styled_messages,
             "temperature": self._temperature,
         }
-        async with httpx.AsyncClient(**_httpx_client_kwargs()) as client:
-            resp = await client.post(
-                self._base_url,
-                headers=headers,
-                json=payload,
+        data = await self._post_with_retry(headers, payload)
+        content = str(data["choices"][0]["message"]["content"])
+        usage = data.get("usage") if isinstance(data.get("usage"), dict) else {}
+        if usage.get("total_tokens"):
+            record_usage(
+                prompt_tokens=int(usage.get("prompt_tokens") or 0),
+                completion_tokens=int(usage.get("completion_tokens") or 0),
             )
-            resp.raise_for_status()
-            data = resp.json()
-            content = str(data["choices"][0]["message"]["content"])
-            usage = data.get("usage") if isinstance(data.get("usage"), dict) else {}
-            if usage.get("total_tokens"):
-                record_usage(
-                    prompt_tokens=int(usage.get("prompt_tokens") or 0),
-                    completion_tokens=int(usage.get("completion_tokens") or 0),
-                )
-            else:
-                prompt_text = "\n".join(
-                    f"{m.get('role', 'user')}: {m.get('content', '')}" for m in messages
-                )
-                record_usage(
-                    prompt_tokens=estimate_tokens(prompt_text),
-                    completion_tokens=estimate_tokens(content),
-                    is_estimate=True,
-                )
-            return content
+        else:
+            prompt_text = "\n".join(
+                f"{m.get('role', 'user')}: {m.get('content', '')}" for m in messages
+            )
+            record_usage(
+                prompt_tokens=estimate_tokens(prompt_text),
+                completion_tokens=estimate_tokens(content),
+                is_estimate=True,
+            )
+        return content
 
 
 def get_llm_client(overrides: LlmOverrides | None = None) -> LLMClient:

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -34,7 +34,7 @@
         "typescript": "^5.6.3",
         "typescript-eslint": "^8.61.0",
         "vite": "^5.4.11",
-        "vitest": "^4.1.8"
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -538,40 +538,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmmirror.com/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmmirror.com/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmmirror.com/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1278,310 +1244,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmmirror.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.3"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
-    "node_modules/@oxc-project/types": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmmirror.com/@oxc-project/types/-/types-0.133.0.tgz",
-      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      }
-    },
-    "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
-      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
-      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
-      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
-      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
-      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
-      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
-      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
-      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
-      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
-      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
-      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
-      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
-      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
-      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
-      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmmirror.com/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1978,13 +1640,6 @@
         "win32"
       ]
     },
-    "node_modules/@standard-schema/spec": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmmirror.com/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -2059,17 +1714,6 @@
         "@types/react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmmirror.com/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
-      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/aria-query": {
@@ -2508,60 +2152,86 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmmirror.com/@vitest/expect/-/expect-4.1.8.tgz",
-      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmmirror.com/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
-        "chai": "^6.2.2",
-        "tinyrainbow": "^3.1.0"
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/pretty-format": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmmirror.com/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
-      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmmirror.com/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.1.0"
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmmirror.com/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmmirror.com/@vitest/runner/-/runner-4.1.8.tgz",
-      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmmirror.com/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.8",
-        "pathe": "^2.0.3"
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmmirror.com/@vitest/snapshot/-/snapshot-4.1.8.tgz",
-      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmmirror.com/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/utils": "4.1.8",
-        "magic-string": "^0.30.21",
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2569,25 +2239,28 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmmirror.com/@vitest/spy/-/spy-4.1.8.tgz",
-      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmmirror.com/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmmirror.com/@vitest/utils/-/utils-4.1.8.tgz",
-      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmmirror.com/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -2768,6 +2441,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmmirror.com/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001799",
       "resolved": "https://registry.npmmirror.com/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
@@ -2800,11 +2483,18 @@
       }
     },
     "node_modules/chai": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmmirror.com/chai/-/chai-6.2.2.tgz",
-      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmmirror.com/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
       "engines": {
         "node": ">=18"
       }
@@ -2847,6 +2537,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmmirror.com/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/comma-separated-tokens": {
@@ -2959,6 +2659,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmmirror.com/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmmirror.com/deep-is/-/deep-is-0.1.4.tgz",
@@ -2973,16 +2683,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmmirror.com/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/devlop": {
@@ -3027,9 +2727,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmmirror.com/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmmirror.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3949,279 +3649,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmmirror.com/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "detect-libc": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
-      }
-    },
-    "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmmirror.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmmirror.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmmirror.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmmirror.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmmirror.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmmirror.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmmirror.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmmirror.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmmirror.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmmirror.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmmirror.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/lightweight-charts": {
       "version": "4.2.3",
       "resolved": "https://registry.npmmirror.com/lightweight-charts/-/lightweight-charts-4.2.3.tgz",
@@ -4268,6 +3695,13 @@
       "bin": {
         "loose-envify": "cli.js"
       }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmmirror.com/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -5230,20 +4664,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/obug": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmmirror.com/obug/-/obug-2.1.3.tgz",
-      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/sxzz",
-        "https://opencollective.com/debug"
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmmirror.com/optionator/-/optionator-0.9.4.tgz",
@@ -5358,6 +4778,16 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5691,47 +5121,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rolldown": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmmirror.com/rolldown/-/rolldown-1.0.3.tgz",
-      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oxc-project/types": "=0.133.0",
-        "@rolldown/pluginutils": "^1.0.0"
-      },
-      "bin": {
-        "rolldown": "bin/cli.mjs"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.3",
-        "@rolldown/binding-darwin-arm64": "1.0.3",
-        "@rolldown/binding-darwin-x64": "1.0.3",
-        "@rolldown/binding-freebsd-x64": "1.0.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
-        "@rolldown/binding-linux-arm64-musl": "1.0.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-musl": "1.0.3",
-        "@rolldown/binding-openharmony-arm64": "1.0.3",
-        "@rolldown/binding-wasm32-wasi": "1.0.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
-        "@rolldown/binding-win32-x64-msvc": "1.0.3"
-      }
-    },
-    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmmirror.com/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
-      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/rollup": {
       "version": "4.62.0",
       "resolved": "https://registry.npmmirror.com/rollup/-/rollup-4.62.0.tgz",
@@ -5867,9 +5256,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmmirror.com/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmmirror.com/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5899,6 +5288,26 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmmirror.com/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/style-to-js": {
       "version": "1.1.21",
@@ -5933,14 +5342,11 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmmirror.com/tinyexec/-/tinyexec-1.2.4.tgz",
-      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmmirror.com/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
@@ -5959,10 +5365,30 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
     "node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmmirror.com/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmmirror.com/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6047,14 +5473,6 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6345,6 +5763,29 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmmirror.com/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
@@ -6793,79 +6234,65 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmmirror.com/vitest/-/vitest-4.1.8.tgz",
-      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmmirror.com/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.8",
-        "@vitest/mocker": "4.1.8",
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/runner": "4.1.8",
-        "@vitest/snapshot": "4.1.8",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
-        "es-module-lexer": "^2.0.0",
-        "expect-type": "^1.3.0",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^4.0.0-rc.1",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
         "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.8",
-        "@vitest/browser-preview": "4.1.8",
-        "@vitest/browser-webdriverio": "4.1.8",
-        "@vitest/coverage-istanbul": "4.1.8",
-        "@vitest/coverage-v8": "4.1.8",
-        "@vitest/ui": "4.1.8",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
         "happy-dom": "*",
-        "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "jsdom": "*"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@opentelemetry/api": {
+        "@types/debug": {
           "optional": true
         },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser-playwright": {
-          "optional": true
-        },
-        "@vitest/browser-preview": {
-          "optional": true
-        },
-        "@vitest/browser-webdriverio": {
-          "optional": true
-        },
-        "@vitest/coverage-istanbul": {
-          "optional": true
-        },
-        "@vitest/coverage-v8": {
+        "@vitest/browser": {
           "optional": true
         },
         "@vitest/ui": {
@@ -6875,129 +6302,6 @@
           "optional": true
         },
         "jsdom": {
-          "optional": true
-        },
-        "vite": {
-          "optional": false
-        }
-      }
-    },
-    "node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmmirror.com/@vitest/mocker/-/mocker-4.1.8.tgz",
-      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "4.1.8",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vitest/node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmmirror.com/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/vitest/node_modules/vite": {
-      "version": "8.0.16",
-      "resolved": "https://registry.npmmirror.com/vite/-/vite-8.0.16.tgz",
-      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.15",
-        "rolldown": "1.0.3",
-        "tinyglobby": "^0.2.17"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.18",
-        "esbuild": "^0.27.0 || ^0.28.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "@vitejs/devtools": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
           "optional": true
         }
       }

--- a/web/package.json
+++ b/web/package.json
@@ -38,6 +38,6 @@
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.61.0",
     "vite": "^5.4.11",
-    "vitest": "^4.1.8"
+    "vitest": "^3.2.4"
   }
 }

--- a/web/src/ChatPanel.tsx
+++ b/web/src/ChatPanel.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import type { ExecutionPreference, HoldingEnriched, StockChoiceCardData } from "./api";
 import type { Message } from "./appTypes";
 import type { AppMode } from "./modeSettings";
@@ -113,6 +114,34 @@ function ProcessStreamFeed({
   );
 }
 
+// Keep the conversation pinned to the bottom as new messages and stream
+// chunks arrive, unless the user has scrolled up to read history.
+function useAutoScroll(messageCount: number) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const nearBottomRef = useRef(true);
+
+  const handleScroll = () => {
+    const el = containerRef.current;
+    if (!el) return;
+    nearBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+  };
+
+  useEffect(() => {
+    if (!nearBottomRef.current) return;
+    const el = containerRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  });
+
+  useEffect(() => {
+    // New turn started — jump to the bottom regardless of scroll position.
+    nearBottomRef.current = true;
+    const el = containerRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messageCount]);
+
+  return { containerRef, handleScroll };
+}
+
 export function ChatPanel({
   messages,
   loading,
@@ -130,6 +159,7 @@ export function ChatPanel({
   onConfirmRoute,
 }: ChatPanelProps) {
   const { t } = useI18n();
+  const { containerRef, handleScroll } = useAutoScroll(messages.length);
 
   function renderAssistantConclusion(m: Message) {
     const researchReport = findResearchReport(m.cards);
@@ -156,7 +186,7 @@ export function ChatPanel({
 
   return (
     <div className="panel chat-panel">
-      <div className="chat-messages">
+      <div className="chat-messages" ref={containerRef} onScroll={handleScroll}>
         {messages.length === 0 && !loading && (
           <div className="chat-empty">
             <p className="chat-empty-label">{t("chat.emptyHint")}</p>
@@ -190,7 +220,7 @@ export function ChatPanel({
           </div>
         )}
         {messages.map((m, i) => (
-          <div key={i} className="chat-turn">
+          <div key={`${i}-${m.role}`} className="chat-turn">
             {m.role === "user" ? (
               <div className="message user">
                 <MarkdownContent text={m.content} />

--- a/web/src/DimensionCards.tsx
+++ b/web/src/DimensionCards.tsx
@@ -151,7 +151,7 @@ export function DimensionCards({ items, labels, defaultOpen = false }: Dimension
                   <ul className="dimension-evidence-list">
                     {item.evidence!.map((ev, idx) => (
                       <li key={`${ev.source}-${idx}`}>
-                        {ev.url ? (
+                        {ev.url && /^https?:\/\//i.test(ev.url) ? (
                           <a href={ev.url} target="_blank" rel="noreferrer">
                             {ev.snippet}
                           </a>

--- a/web/src/StockChart.tsx
+++ b/web/src/StockChart.tsx
@@ -131,6 +131,7 @@ export function MarketChart({ symbol, compact = false, variant = "stock" }: Mark
   const skipDataEffectRef = useRef(false);
   const syncingRangeRef = useRef(false);
   const barsRef = useRef<KlineBar[]>([]);
+  const symbolRef = useRef(symbol);
 
   const [data, setData] = useState<KlineChart | null>(() => getCachedKline(symbol));
   const dataRef = useRef<KlineChart | null>(data);
@@ -277,6 +278,7 @@ export function MarketChart({ symbol, compact = false, variant = "stock" }: Mark
     const earliest = bars[0]?.date;
     if (!earliest) return;
 
+    const requestedSymbol = symbol;
     const nextDays = Math.min(bars.length + LOAD_CHUNK, MAX_BARS);
     const useSinaExpand = nextDays <= SINA_EXPAND_LIMIT;
 
@@ -289,6 +291,9 @@ export function MarketChart({ symbol, compact = false, variant = "stock" }: Mark
 
     fetchPromise
       .then((chunk) => {
+        // The user switched stocks while this page request was in flight —
+        // discard the stale chunk so it cannot pollute the new symbol's bars.
+        if (symbolRef.current !== requestedSymbol) return;
         if (!chunk.bars.length) {
           exhaustedRef.current = true;
           return;
@@ -327,6 +332,7 @@ export function MarketChart({ symbol, compact = false, variant = "stock" }: Mark
   }, [applyChart, symbol]);
 
   useEffect(() => {
+    symbolRef.current = symbol;
     exhaustedRef.current = false;
     loadingMoreRef.current = false;
     initialPaintRef.current = true;

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -62,18 +62,23 @@ async function fetchWithRetry(
   retries = RETRY_COUNT,
   timeoutMs = DEFAULT_TIMEOUT_MS,
 ): Promise<Response> {
+  // Only idempotent methods are safe to retry — retrying a POST/PUT/DELETE
+  // that already reached the server could duplicate writes (holdings, trades).
+  const method = (options.method ?? "GET").toUpperCase();
+  const idempotent = method === "GET" || method === "HEAD" || method === "OPTIONS";
+  const maxAttempts = idempotent ? retries : 0;
   let lastError: Error | null = null;
-  for (let attempt = 0; attempt <= retries; attempt++) {
+  for (let attempt = 0; attempt <= maxAttempts; attempt++) {
     try {
       const resp = await fetchWithTimeout(url, options, timeoutMs);
-      if (resp.status >= 500 && attempt < retries) {
+      if (resp.status >= 500 && attempt < maxAttempts) {
         await new Promise((r) => setTimeout(r, RETRY_DELAY_MS * (attempt + 1)));
         continue;
       }
       return resp;
     } catch (err) {
       lastError = err as Error;
-      if (attempt < retries) {
+      if (attempt < maxAttempts) {
         await new Promise((r) => setTimeout(r, RETRY_DELAY_MS * (attempt + 1)));
       }
     }
@@ -240,6 +245,7 @@ export const api = {
     sessionId?: string,
     onEvent?: (event: AgentStreamEvent) => void,
     options?: ChatStreamOptions,
+    signal?: AbortSignal,
   ) =>
     createJsonSseStream<ChatResponse, AgentStreamEvent>({
       url: apiUrl("/chat/stream"),
@@ -256,6 +262,7 @@ export const api = {
         ...llmBodyField(),
       },
       onEvent,
+      signal,
       extractResult: (event) =>
         event.type === "done" && event.response ? (event.response as ChatResponse) : undefined,
     }),
@@ -501,7 +508,7 @@ export const api = {
     signal?: AbortSignal,
   ) =>
     createJsonSseStream<NewsAnalysis, AgentStreamEvent>({
-      url: apiUrl(`/news/${newsId}/analyze/stream?symbol=${symbol}`),
+      url: apiUrl(`/news/${newsId}/analyze/stream?symbol=${encodeURIComponent(symbol)}`),
       headers: llmRequestHeaders(),
       signal,
       onEvent,
@@ -516,7 +523,7 @@ export const api = {
     request<SentimentData>(`/market/sector-sentiment?name=${encodeURIComponent(name)}`),
   stockSentiment: (symbol: string, name?: string) =>
     request<SentimentData>(
-      `/market/stock-sentiment?symbol=${symbol}&name=${encodeURIComponent(name ?? "")}`,
+      `/market/stock-sentiment?symbol=${encodeURIComponent(symbol)}&name=${encodeURIComponent(name ?? "")}`,
     ),
 };
 

--- a/web/src/apiSse.ts
+++ b/web/src/apiSse.ts
@@ -65,14 +65,16 @@ async function consumeSse<E extends SseEvent>(
     while (true) {
       if (timedOut) break;
       const readPromise = reader.read();
+      let timerId: ReturnType<typeof setTimeout> | undefined;
       const timeoutPromise = new Promise<never>((_, reject) => {
-        setTimeout(() => {
+        timerId = setTimeout(() => {
           reject(new Error("SSE connection timed out — no data received for 60s"));
         }, timeoutMs);
       });
 
       try {
         const { done, value } = await Promise.race([readPromise, timeoutPromise]);
+        if (timerId !== undefined) clearTimeout(timerId);
         if (done) break;
         buffer += decoder.decode(value, { stream: true });
         const lines = buffer.split("\n");
@@ -89,6 +91,7 @@ async function consumeSse<E extends SseEvent>(
           }
         }
       } catch (err) {
+        if (timerId !== undefined) clearTimeout(timerId);
         reader.cancel().catch(() => {});
         if (err instanceof Error && err.message.includes("timed out")) break;
         throw err;

--- a/web/src/hooks/useChatExecution.ts
+++ b/web/src/hooks/useChatExecution.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import {
   api,
   type AgentStreamEvent,
@@ -101,6 +101,7 @@ export function useChatExecution(options: UseChatExecutionOptions): ChatExecutio
 
   const [chatLoading, setChatLoading] = useState(false);
   const [statusMsg, setStatusMsg] = useState("");
+  const abortRef = useRef<AbortController | null>(null);
 
   const executeChat = useCallback(
     async (
@@ -111,6 +112,10 @@ export function useChatExecution(options: UseChatExecutionOptions): ChatExecutio
     ) => {
       const threadId = turn?.threadId;
       const activeSessionId = turn?.sessionId ?? sessionId;
+      // Abort any in-flight stream before starting a new one.
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
       setChatLoading(true);
       setStatusMsg(t("chat.connecting"));
       setChatStream(() => emptyStreamState());
@@ -137,8 +142,16 @@ export function useChatExecution(options: UseChatExecutionOptions): ChatExecutio
             }
           },
           resolvedOptions,
+          controller.signal,
         );
-        if (resp) {
+        // Superseded by a newer turn — drop the stale result.
+        if (controller.signal.aborted) return;
+        if (!resp) {
+          // SSE ended without a done event (timeout/disconnect); fall back to
+          // the sync endpoint instead of silently dropping the user's query.
+          throw new Error("chat stream ended without a result");
+        }
+        {
           setSessionId(resp.session_id, threadId);
           processSnapshot = finalizeStreamState(
             { ...processSnapshot, streamStatus: t("chat.analysisDone") },
@@ -170,6 +183,8 @@ export function useChatExecution(options: UseChatExecutionOptions): ChatExecutio
           });
         }
       } catch (err) {
+        // Aborted (superseded or cancelled) — not an error to surface.
+        if (controller.signal.aborted) return;
         if (err instanceof TypeError && String(err).includes("Failed to fetch")) {
           appendMessages(
             (m) => [...m, { role: "assistant", content: formatChatRequestError(err, t) }],
@@ -211,8 +226,13 @@ export function useChatExecution(options: UseChatExecutionOptions): ChatExecutio
           );
         }
       } finally {
-        setChatLoading(false);
-        setStatusMsg("");
+        // Only clear loading/status if this turn is still the active one; a
+        // superseding turn manages its own lifecycle.
+        if (abortRef.current === controller) {
+          abortRef.current = null;
+          setChatLoading(false);
+          setStatusMsg("");
+        }
       }
     },
     [

--- a/web/src/hooks/useCopilotThreads.ts
+++ b/web/src/hooks/useCopilotThreads.ts
@@ -21,10 +21,12 @@ export interface PrepareUserTurnResult {
 }
 
 export function useCopilotThreads({ defaultTitle }: UseCopilotThreadsOptions) {
-  const [threads, setThreads] = useState<CopilotThread[]>(() => loadCopilotThreads(defaultTitle));
-  const [activeId, setActiveId] = useState<string>(
-    () => loadCopilotThreads(defaultTitle)[0]?.id ?? "",
-  );
+  // Load once and derive both states from the SAME array. Calling
+  // loadCopilotThreads() twice (two lazy initializers) creates two different
+  // threads when storage is empty, leaving activeId pointing at a ghost.
+  const [initialThreads] = useState(() => loadCopilotThreads(defaultTitle));
+  const [threads, setThreads] = useState<CopilotThread[]>(initialThreads);
+  const [activeId, setActiveId] = useState<string>(() => initialThreads[0]?.id ?? "");
   const [chatStream, setChatStream] = useState(emptyStreamState());
   const [input, setInput] = useState("");
   const threadsRef = useRef(threads);
@@ -78,24 +80,26 @@ export function useCopilotThreads({ defaultTitle }: UseCopilotThreadsOptions) {
 
   const deleteThread = useCallback(
     (id: string) => {
-      setThreads((prev) => {
-        const next = prev.filter((t) => t.id !== id);
-        if (next.length === 0) {
-          const created = createThread(defaultTitle);
-          setActiveId(created.id);
-          activeIdRef.current = created.id;
-          return [created];
-        }
-        if (id === activeIdRef.current) {
-          setActiveId(next[0].id);
-          activeIdRef.current = next[0].id;
-          setChatStream(emptyStreamState());
-          setInput("");
-        }
-        return next;
-      });
+      // Compute from the synced ref and apply state changes outside any
+      // updater — side effects inside a setThreads updater run twice in
+      // StrictMode and are order-dependent.
+      const next = threadsRef.current.filter((t) => t.id !== id);
+      if (next.length === 0) {
+        const created = createThread(defaultTitle);
+        setThreads([created]);
+        setActiveId(created.id);
+        activeIdRef.current = created.id;
+        return;
+      }
+      setThreads(next);
+      if (id === activeIdRef.current) {
+        setActiveId(next[0].id);
+        activeIdRef.current = next[0].id;
+        setChatStream(emptyStreamState());
+        setInput("");
+      }
     },
-    [defaultTitle],
+    [defaultTitle, setChatStream],
   );
 
   /** Append a user turn to the active thread. Only Plus (`newThread`) starts a new line. */

--- a/web/src/locales/zh.ts
+++ b/web/src/locales/zh.ts
@@ -1079,7 +1079,7 @@ export const zh: Dict = {
         start: "启动 {name}（{symbol}）四维投研…",
         fetch_data: "正在获取{agent}数据…",
         news_factor: "四维完成，压缩新闻文本因子…",
-        summarize: "汇总作战情与文本因子…",
+        summarize: "汇总作战情报与文本因子…",
         report_done: "投研报告已生成",
         battle_start: "进入多空 Battle…",
       },
@@ -1087,7 +1087,7 @@ export const zh: Dict = {
         research: {
           start: "启动 A 股市场四维深度投研…",
           news_factor: "四维完成，压缩市场新闻文本因子…",
-          summarize: "汇总市场作战情与文本因子…",
+          summarize: "汇总市场作战情报与文本因子…",
           report_done: "市场深度投研报告已生成",
           battle_start: "进入大盘多空 Battle…",
         },


### PR DESCRIPTION
## 背景
对全仓代码进行整体审计（4 个专项审计代理 + 关键发现人工核验），本 PR 修复全部可落地的问题。

## 安全
- API 默认绑定 `127.0.0.1`（原 `0.0.0.0`）
- `X-LLM-Base-Url` 覆盖时不再回退服务端 `LLM_API_KEY`，堵住密钥外泄链
- 写 `.env` 前净化不可打印字符，防换行注入
- `/market/quotes` 单次最多 100 个标的

## 后端可靠性
- SSE pump 异常兜底，保证 `_PUMP_DONE` 哨兵必达（流不再永久挂起）
- 风控体检缺失行情用占位 Quote 对齐，不再因 `zip(strict)` 崩溃
- 客户端断开时取消 `turn_task`，避免 LLM 泄漏
- ReAct/plan-execute 总超时；LLM 调用指数退避重试
- 裁判/倾向解析修复看多偏置
- plan_execute 更新废弃工具名，移除硬编码对比标的
- financial agent 阻塞调用改 `asyncio.to_thread`
- SQLite WAL + busy_timeout=30s
- kimi CLI 落地 `kimi_live_max_calls_per_day` 每日配额

## 前端健壮性
- fetchWithRetry 仅幂等方法重试
- 聊天流 AbortController 取消 + 读超时抛错走同步兜底
- 证据链接 http(s) 协议校验；查询参数编码
- StockChart 分页竞态守卫
- 冷启动幽灵线程修复；ChatPanel 自动滚动贴底 + key 稳定化
- SSE 消费定时器泄漏修复

## 杂项
- 错别字修正、vitest 降为 ^3（vite 5 peer 对齐）、ruff UP047/UP038

## 验证
- `pytest`: 607 passed / 3 skipped
- `ruff check`: 0 错误（含 pre-commit 新版 ruff）
- `vitest`: 71 passed
- `tsc && vite build`: 成功