### PR TITLE
docs: README/PRD 标题行加入应用图标

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,4 +1,4 @@
-# StockResearch — English
+# StockResearch <img src="desktop/branding/app-icon.png" alt="StockResearch logo" width="36" height="36" align="middle"> — English
 
 The repository homepage README is **bilingual** (Chinese + English).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# StockResearch
+# StockResearch <img src="desktop/branding/app-icon.png" alt="StockResearch logo" width="36" height="36" align="middle">
 
 **[中文](#中文) · [English](#english)** · [PRD v10.16](docs/PRD.md)
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,4 +1,4 @@
-# StockResearch 产品需求文档
+# StockResearch <img src="../desktop/branding/app-icon.png" alt="StockResearch logo" width="32" height="32" align="middle"> 产品需求文档
 
 **V10.17 · 开源 A 股市场研究 Agent**
 


### PR DESCRIPTION
## 变更内容

将打磨后的圆角矩形应用图标（desktop/branding/app-icon.png）嵌入文档标题行：

- **README.md**：36×36 图标（GitHub 仓库主界面）
- **README.en.md**：36×36 图标（英文版）
- **docs/PRD.md**：32×32 图标

图标与 #35 桌面图标更新保持同一品牌资源。