### PR TITLE
feat(ui): 组合驾驶舱与功能排布重构

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -627,6 +627,8 @@ export default function App() {
               {centerTab === "focus" && !focusContext && focusTabs.length === 0 && (
                 <FocusEmptyState
                   holdingsCount={holdings.length}
+                  watchlistCount={watchlist.length}
+                  portfolioSummary={portfolioSummary}
                   isDemo={isDemo}
                   demoLoading={demoLoading}
                   highlightSector={highlightSector}

--- a/web/src/ListsSidebar.tsx
+++ b/web/src/ListsSidebar.tsx
@@ -2,8 +2,6 @@ import { useMemo, useState, type ReactNode } from "react";
 import type { HoldingEnriched, WatchlistItem, StockQuoteOut } from "./api";
 import { HoldingTradeInlineRow } from "./HoldingTradeInlineRow";
 import { ListsStockTable } from "./ListsStockTable";
-import { PortfolioLedgerSections } from "./PortfolioLedger";
-import { PortfolioEventsScreener } from "./PortfolioEventsScreener";
 import {
   formatMoney,
   formatPrice,
@@ -153,14 +151,6 @@ export function ListsSidebar({
   const listsDetail = expanded || listsWidth >= LISTS_DETAIL_WIDTH;
   const profitClass = signedClass(portfolioSummary.totalProfitPct);
   const todayClass = signedClass(portfolioSummary.todayPnlPct);
-  const ledgerTrigger = useMemo(
-    () => holdings.map((h) => `${h.symbol}:${h.quantity}`).join(","),
-    [holdings],
-  );
-  const eventsTrigger = useMemo(
-    () => `${ledgerTrigger}|${watchlist.map((w) => w.symbol).join(",")}`,
-    [ledgerTrigger, watchlist],
-  );
 
   return (
     <aside
@@ -265,12 +255,6 @@ export function ListsSidebar({
             </div>
           ))}
       </section>
-
-      {holdings.length > 0 && <PortfolioLedgerSections trigger={ledgerTrigger} />}
-
-      {(holdings.length > 0 || watchlist.length > 0) && (
-        <PortfolioEventsScreener trigger={eventsTrigger} />
-      )}
 
       {sectorMix.length > 0 && (
         <CollapsibleSection title={t("lists.sectors")}>

--- a/web/src/MarketPanel.tsx
+++ b/web/src/MarketPanel.tsx
@@ -11,6 +11,7 @@ import { signedClass } from "./holdingDisplay";
 import { useI18n } from "./i18n";
 import { localizeIndexName } from "./indexLabels";
 import { SectorStripCards, type SectorStripItem } from "./SectorStripCards";
+import { FactorScreenerSection } from "./PortfolioEventsScreener";
 import { localizeSentiment } from "./uiLabels";
 import { SentimentGauge } from "./SentimentGauge";
 import { loadModeSettings } from "./modeSettings";
@@ -185,6 +186,10 @@ export function MarketPanel({
         ) : (
           <SectorStripCards items={sectorCards} ariaLabel={t("market.sectorsTitle")} />
         )}
+      </section>
+
+      <section className="market-section market-section-screener">
+        <FactorScreenerSection />
       </section>
 
       <section className="market-section">

--- a/web/src/PortfolioCockpit.tsx
+++ b/web/src/PortfolioCockpit.tsx
@@ -1,15 +1,22 @@
-/** Portfolio NAV curve vs benchmark + trade ledger (decision journal) sections. */
+/**
+ * Portfolio cockpit — “今日关注”首页的组合驾驶舱。
+ *
+ * 组合日线（90 天净值 vs 沪深300）+ 决策台账（交易记录）+ 组合事件（财报/解禁）。
+ * 有持仓时替换原空状态引导中的市场速览，板块异动与快讯下沉到底部。
+ */
 
 import { useEffect, useMemo, useState } from "react";
 import { api, type PortfolioPerformance, type TradeRecord } from "./api";
 import { CollapsibleSection } from "./CollapsibleSection";
+import { PortfolioEventsSection } from "./PortfolioEventsScreener";
 import { formatSignedMoney, formatSignedPct, signedClass } from "./holdingDisplay";
 import { useI18n } from "./i18n";
+import type { PortfolioSummary } from "./portfolioHelpers";
 
-const CHART_W = 220;
-const CHART_H = 52;
 const PERF_DAYS = 90;
-const TRADE_LIMIT = 8;
+const TRADE_LIMIT = 10;
+const CHART_W = 480;
+const CHART_H = 132;
 
 function linePath(values: number[], allMin: number, allMax: number): string {
   if (values.length < 2) return "";
@@ -18,13 +25,13 @@ function linePath(values: number[], allMin: number, allMax: number): string {
   return values
     .map((v, i) => {
       const x = i * step;
-      const y = CHART_H - 3 - ((v - allMin) / span) * (CHART_H - 6);
+      const y = CHART_H - 6 - ((v - allMin) / span) * (CHART_H - 12);
       return `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`;
     })
     .join(" ");
 }
 
-function PerfChart({ perf }: { perf: PortfolioPerformance }) {
+function CockpitPerfChart({ perf }: { perf: PortfolioPerformance }) {
   const { portfolio, benchmark, min, max } = useMemo(() => {
     const p = perf.series.map((pt) => pt.portfolio_index);
     const b = perf.series.map((pt) => pt.benchmark_index);
@@ -39,7 +46,7 @@ function PerfChart({ perf }: { perf: PortfolioPerformance }) {
 
   return (
     <svg
-      className="ledger-perf-chart"
+      className="cockpit-perf-chart"
       viewBox={`0 0 ${CHART_W} ${CHART_H}`}
       preserveAspectRatio="none"
       role="img"
@@ -57,7 +64,7 @@ function PerfChart({ perf }: { perf: PortfolioPerformance }) {
         d={linePath(portfolio, min, max)}
         fill="none"
         stroke="var(--accent)"
-        strokeWidth="2"
+        strokeWidth="2.5"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
@@ -76,8 +83,19 @@ const BIAS_LABEL_KEYS: Record<string, string> = {
   neutral: "portfolio.biasNeutral",
 };
 
-export function PortfolioLedgerSections({ trigger }: { trigger: string }) {
+interface PortfolioCockpitProps {
+  holdingsCount: number;
+  watchlistCount: number;
+  portfolioSummary: PortfolioSummary | null;
+}
+
+export function PortfolioCockpit({
+  holdingsCount,
+  watchlistCount,
+  portfolioSummary,
+}: PortfolioCockpitProps) {
   const { t } = useI18n();
+  const trigger = `${holdingsCount}:${watchlistCount}`;
   const [perf, setPerf] = useState<PortfolioPerformance | null>(null);
   const [trades, setTrades] = useState<TradeRecord[]>([]);
 
@@ -96,8 +114,6 @@ export function PortfolioLedgerSections({ trigger }: { trigger: string }) {
     };
   }, [trigger]);
 
-  if (!perf && trades.length === 0) return null;
-
   const perfSummary =
     perf && perf.portfolio_return_pct != null ? (
       <span className={`ledger-perf-summary mono ${signedClass(perf.portfolio_return_pct)}`}>
@@ -105,13 +121,46 @@ export function PortfolioLedgerSections({ trigger }: { trigger: string }) {
       </span>
     ) : undefined;
 
+  const pnl = portfolioSummary;
+
   return (
     <>
+      {pnl && pnl.hasQuotes && (
+        <section className="flat-section cockpit-snapshot">
+          <div className="cockpit-snapshot-head">
+            <span className="flat-section-title">{t("center.focus")}</span>
+            <span className="cockpit-snapshot-value mono">{formatSignedMoney(pnl.todayPnl)}</span>
+          </div>
+          <div className="cockpit-snapshot-metrics mono">
+            <span className={`lists-portfolio-metric ${signedClass(pnl.todayPnl)}`}>
+              <span className="lists-metric-label">{t("lists.todayPnl")}</span>
+              <span>{formatSignedMoney(pnl.todayPnl)}</span>
+            </span>
+            <span className={`lists-portfolio-metric ${signedClass(pnl.todayPnlPct ?? 0)}`}>
+              <span className="lists-metric-label">{t("lists.todayPnlPct")}</span>
+              <span>{formatSignedPct(pnl.todayPnlPct)}</span>
+            </span>
+            <span className={`lists-portfolio-metric ${signedClass(pnl.totalProfit)}`}>
+              <span className="lists-metric-label">{t("lists.totalPnl")}</span>
+              <span>{formatSignedMoney(pnl.totalProfit)}</span>
+            </span>
+            <span className={`lists-portfolio-metric ${signedClass(pnl.totalProfitPct ?? 0)}`}>
+              <span className="lists-metric-label">{t("lists.totalPnlPct")}</span>
+              <span>{formatSignedPct(pnl.totalProfitPct)}</span>
+            </span>
+            <span className={`lists-portfolio-metric ${signedClass(pnl.annualizedPct ?? 0)}`}>
+              <span className="lists-metric-label">{t("portfolio.annualized")}</span>
+              <span>{pnl.annualizedPct != null ? formatSignedPct(pnl.annualizedPct) : "—"}</span>
+            </span>
+          </div>
+        </section>
+      )}
+
       {perf && (
         <CollapsibleSection title={t("portfolio.perfTitle")} summary={perfSummary}>
           {perf.series.length > 0 ? (
-            <div className="ledger-perf-body">
-              <PerfChart perf={perf} />
+            <div className="cockpit-perf-body">
+              <CockpitPerfChart perf={perf} />
               <div className="ledger-perf-legend mono">
                 <span className="ledger-perf-item">
                   <i className="ledger-perf-dot ledger-perf-dot-portfolio" />
@@ -183,6 +232,8 @@ export function PortfolioLedgerSections({ trigger }: { trigger: string }) {
           <p className="muted ledger-perf-basis">{t("portfolio.tradesHint")}</p>
         </CollapsibleSection>
       )}
+
+      <PortfolioEventsSection trigger={trigger} />
     </>
   );
 }

--- a/web/src/PortfolioEventsScreener.tsx
+++ b/web/src/PortfolioEventsScreener.tsx
@@ -1,4 +1,10 @@
-/** Event calendar (earnings / lockup) + factor screener sections. */
+/**
+ * Portfolio event calendar (earnings / lockup) + factor screener sections.
+ *
+ * Two independent exports:
+ * - PortfolioEventsSection  → 组合事件日历（用于“今日关注”组合驾驶舱）
+ * - FactorScreenerSection  → 全市场因子筛选（用于“市场”Tab）
+ */
 
 import { useEffect, useState } from "react";
 import { api, type PortfolioEvents, type ScreenCondition, type ScreenResult } from "./api";
@@ -35,12 +41,10 @@ const FACTOR_LABEL_KEYS: Record<string, string> = {
   pe_percentile: "portfolio.screenFactorPe",
 };
 
-export function PortfolioEventsScreener({ trigger }: { trigger: string }) {
+/** 组合事件日历：未来 N 天内持仓/自选的财报、解禁日程。 */
+export function PortfolioEventsSection({ trigger = "" }: { trigger?: string }) {
   const { t } = useI18n();
   const [events, setEvents] = useState<PortfolioEvents | null>(null);
-  const [screen, setScreen] = useState<ScreenResult | null>(null);
-  const [preset, setPreset] = useState<PresetKey | null>(null);
-  const [screening, setScreening] = useState(false);
 
   useEffect(() => {
     let alive = true;
@@ -57,6 +61,49 @@ export function PortfolioEventsScreener({ trigger }: { trigger: string }) {
     };
   }, [trigger]);
 
+  const eventSummary =
+    events && events.events.length > 0 ? (
+      <span className="mono ledger-events-count">{events.events.length}</span>
+    ) : undefined;
+
+  return (
+    <CollapsibleSection title={t("portfolio.eventsTitle")} summary={eventSummary} defaultCollapsed>
+      {events && events.events.length > 0 ? (
+        <ul className="ledger-events">
+          {events.events.map((ev) => (
+            <li key={`${ev.kind}-${ev.symbol}-${ev.event_date}`} className="ledger-event-row">
+              <span className="mono ledger-event-date">{ev.event_date.slice(5)}</span>
+              <span className={`ledger-event-kind ${ev.kind}`}>
+                {ev.kind === "earnings"
+                  ? t("portfolio.eventsEarnings")
+                  : t("portfolio.eventsLockup")}
+              </span>
+              <span className="ledger-event-name" title={ev.detail || ev.name}>
+                {ev.name}
+              </span>
+              <span className="muted ledger-event-detail">{ev.detail || ""}</span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="muted flat-empty">
+          {events ? events.message || t("portfolio.eventsEmpty") : t("portfolio.eventsEmpty")}
+        </p>
+      )}
+      {events?.partial && events.message && events.events.length > 0 && (
+        <p className="muted ledger-perf-basis">{events.message}</p>
+      )}
+    </CollapsibleSection>
+  );
+}
+
+/** 因子筛选：预设条件扫描全市场（持仓/自选高亮），用于“市场”Tab。 */
+export function FactorScreenerSection() {
+  const { t } = useI18n();
+  const [screen, setScreen] = useState<ScreenResult | null>(null);
+  const [preset, setPreset] = useState<PresetKey | null>(null);
+  const [screening, setScreening] = useState(false);
+
   const runPreset = (key: PresetKey) => {
     setPreset(key);
     setScreening(true);
@@ -67,97 +114,58 @@ export function PortfolioEventsScreener({ trigger }: { trigger: string }) {
       .finally(() => setScreening(false));
   };
 
-  const eventSummary =
-    events && events.events.length > 0 ? (
-      <span className="mono ledger-events-count">{events.events.length}</span>
-    ) : undefined;
-
   return (
-    <>
-      {events && (
-        <CollapsibleSection
-          title={t("portfolio.eventsTitle")}
-          summary={eventSummary}
-          defaultCollapsed
-        >
-          {events.events.length > 0 ? (
-            <ul className="ledger-events">
-              {events.events.map((ev) => (
-                <li key={`${ev.kind}-${ev.symbol}-${ev.event_date}`} className="ledger-event-row">
-                  <span className="mono ledger-event-date">{ev.event_date.slice(5)}</span>
-                  <span className={`ledger-event-kind ${ev.kind}`}>
-                    {ev.kind === "earnings"
-                      ? t("portfolio.eventsEarnings")
-                      : t("portfolio.eventsLockup")}
+    <CollapsibleSection title={t("portfolio.screenTitle")} defaultCollapsed>
+      <div className="ledger-screen-presets">
+        {PRESET_ORDER.map((key) => (
+          <button
+            key={key}
+            type="button"
+            className={`ledger-screen-chip${preset === key ? " active" : ""}`}
+            onClick={() => runPreset(key)}
+            disabled={screening}
+          >
+            {t(PRESET_LABEL_KEYS[key])}
+          </button>
+        ))}
+      </div>
+      {screening && <p className="muted flat-empty">…</p>}
+      {!screening && screen && (
+        <>
+          {screen.hits.length > 0 ? (
+            <ul className="ledger-screen-hits">
+              {screen.hits.map((hit) => (
+                <li key={hit.symbol} className="ledger-screen-hit">
+                  <span className="ledger-screen-hit-name" title={hit.sector || hit.name}>
+                    {hit.name}
+                    <i className={`ledger-screen-hit-scope ${hit.scope}`} aria-hidden="true" />
                   </span>
-                  <span className="ledger-event-name" title={ev.detail || ev.name}>
-                    {ev.name}
+                  <span className="mono ledger-screen-hit-factors">
+                    {Object.entries(hit.factors).map(([key, value]) => (
+                      <span key={key} className="ledger-screen-hit-factor">
+                        <span className="lists-metric-label">
+                          {t(FACTOR_LABEL_KEYS[key] || key)}
+                        </span>{" "}
+                        <b className={key === "momentum_20d" ? signedClass(value) : ""}>
+                          {value != null ? `${value.toFixed(1)}%` : "—"}
+                        </b>
+                      </span>
+                    ))}
                   </span>
-                  <span className="muted ledger-event-detail">{ev.detail || ""}</span>
                 </li>
               ))}
             </ul>
           ) : (
-            <p className="muted flat-empty">{events.message || t("portfolio.eventsEmpty")}</p>
+            <p className="muted flat-empty">{screen.message || t("portfolio.screenEmpty")}</p>
           )}
-          {events.partial && events.message && events.events.length > 0 && (
-            <p className="muted ledger-perf-basis">{events.message}</p>
-          )}
-        </CollapsibleSection>
+          <p className="muted ledger-perf-basis">
+            {t("portfolio.screenScanned")} {screen.scanned}
+            {screen.skipped > 0 ? ` · ${t("portfolio.screenSkipped")} ${screen.skipped}` : ""}
+            {screen.message ? ` · ${screen.message}` : ""}
+          </p>
+        </>
       )}
-
-      <CollapsibleSection title={t("portfolio.screenTitle")} defaultCollapsed>
-        <div className="ledger-screen-presets">
-          {PRESET_ORDER.map((key) => (
-            <button
-              key={key}
-              type="button"
-              className={`ledger-screen-chip${preset === key ? " active" : ""}`}
-              onClick={() => runPreset(key)}
-              disabled={screening}
-            >
-              {t(PRESET_LABEL_KEYS[key])}
-            </button>
-          ))}
-        </div>
-        {screening && <p className="muted flat-empty">…</p>}
-        {!screening && screen && (
-          <>
-            {screen.hits.length > 0 ? (
-              <ul className="ledger-screen-hits">
-                {screen.hits.map((hit) => (
-                  <li key={hit.symbol} className="ledger-screen-hit">
-                    <span className="ledger-screen-hit-name" title={hit.sector || hit.name}>
-                      {hit.name}
-                      <i className={`ledger-screen-hit-scope ${hit.scope}`} aria-hidden="true" />
-                    </span>
-                    <span className="mono ledger-screen-hit-factors">
-                      {Object.entries(hit.factors).map(([key, value]) => (
-                        <span key={key} className="ledger-screen-hit-factor">
-                          <span className="lists-metric-label">
-                            {t(FACTOR_LABEL_KEYS[key] || key)}
-                          </span>{" "}
-                          <b className={key === "momentum_20d" ? signedClass(value) : ""}>
-                            {value != null ? `${value.toFixed(1)}%` : "—"}
-                          </b>
-                        </span>
-                      ))}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <p className="muted flat-empty">{screen.message || t("portfolio.screenEmpty")}</p>
-            )}
-            <p className="muted ledger-perf-basis">
-              {t("portfolio.screenScanned")} {screen.scanned}
-              {screen.skipped > 0 ? ` · ${t("portfolio.screenSkipped")} ${screen.skipped}` : ""}
-              {screen.message ? ` · ${screen.message}` : ""}
-            </p>
-          </>
-        )}
-        {!screening && !screen && <p className="muted flat-empty">{t("portfolio.screenIdle")}</p>}
-      </CollapsibleSection>
-    </>
+      {!screening && !screen && <p className="muted flat-empty">{t("portfolio.screenIdle")}</p>}
+    </CollapsibleSection>
   );
 }

--- a/web/src/app/FocusEmptyState.tsx
+++ b/web/src/app/FocusEmptyState.tsx
@@ -2,10 +2,14 @@ import { memo } from "react";
 import { ActionCenter } from "../ActionCenter";
 import { BackendHealthBanner } from "../BackendHealthBanner";
 import { DemoBanner } from "../DemoBanner";
+import { PortfolioCockpit } from "../PortfolioCockpit";
 import { SectorMoversPanel } from "../SectorMoversPanel";
+import type { PortfolioSummary } from "../portfolioHelpers";
 
 interface FocusEmptyStateProps {
   holdingsCount: number;
+  watchlistCount: number;
+  portfolioSummary: PortfolioSummary | null;
   isDemo: boolean;
   demoLoading: boolean;
   highlightSector: string | null;
@@ -18,9 +22,16 @@ interface FocusEmptyStateProps {
   onChatQuery: (query: string) => void;
 }
 
-/** Focus-tab landing state (health/demo banners + sector movers + action center). */
+/**
+ * Focus-tab landing state.
+ *
+ * 有持仓时 = 组合驾驶舱（组合日线 / 决策台账 / 组合事件）+ 板块异动与快讯（下沉）；
+ * 无持仓时 = 引导横幅 + 板块异动 + 行动中心。
+ */
 export const FocusEmptyState = memo(function FocusEmptyState({
   holdingsCount,
+  watchlistCount,
+  portfolioSummary,
   isDemo,
   demoLoading,
   highlightSector,
@@ -50,6 +61,13 @@ export const FocusEmptyState = memo(function FocusEmptyState({
           onGoPortfolio={onGoPortfolio}
           isDemo={isDemo}
           loading={demoLoading}
+        />
+      )}
+      {holdingsCount > 0 && (
+        <PortfolioCockpit
+          holdingsCount={holdingsCount}
+          watchlistCount={watchlistCount}
+          portfolioSummary={portfolioSummary}
         />
       )}
       <SectorMoversPanel

--- a/web/src/styles/app/panels.css
+++ b/web/src/styles/app/panels.css
@@ -4018,3 +4018,41 @@
   align-items: baseline;
   white-space: nowrap;
 }
+
+/* ── 组合驾驶舱（今日关注 · 有持仓时） ─────────────────────── */
+.cockpit-snapshot {
+  margin-bottom: 12px;
+}
+.cockpit-snapshot-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.cockpit-snapshot-value {
+  font-size: 18px;
+  font-weight: 600;
+}
+.cockpit-snapshot-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 20px;
+}
+.cockpit-perf-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.cockpit-perf-chart {
+  width: 100%;
+  height: 150px;
+  display: block;
+  border: 1px solid var(--bbg-border, rgba(148, 163, 184, 0.18));
+  border-radius: 8px;
+  padding: 4px 2px;
+  box-sizing: border-box;
+}
+.market-section-screener {
+  margin-bottom: 16px;
+}


### PR DESCRIPTION
## 背景
项目对标 Google Finance（README/PRD 已写入），功能增多后对排布做一次重构：今日关注首页承担"组合驾驶舱"职责。

## 变更
1. **组合驾驶舱**（新增 web/src/PortfolioCockpit.tsx）：有持仓时今日关注首页渲染 组合快照 + 90 天净值走势大图（vs 沪深300）+ 决策台账（交易记录/研报 bias）+ 组合事件（财报/解禁）
2. **因子筛选移入市场 tab**：FactorScreenerSection 挂载到市场页，与行情/行业板块同区
3. **侧栏瘦身**：移除净值走势/事件日历/因子筛选 3 个区块，保留 总持仓摘要 → 行业分布 → 持仓个股 → 自选股
4. 删除无引用 PortfolioLedger.tsx，事件日历抽为独立 PortfolioEventsSection 复用

## 验证
- pytest 全量 617 passed
- npm run build 通过
- 浏览器验证：驾驶舱快照/净值走势/事件日历渲染正常，市场页因子筛选命中正常