### PR TITLE
feat: 净值走势图增加横纵坐标轴

### DIFF
--- a/web/src/PortfolioCockpit.tsx
+++ b/web/src/PortfolioCockpit.tsx
@@ -23,6 +23,10 @@ const PERF_DAYS = 90;
 const TRADE_LIMIT = 10;
 const CHART_W = 480;
 const CHART_H = 132;
+const AXIS_Y_W = 48; // Y 轴标签区宽度（px）
+const AXIS_X_H = 20; // X 轴标签区高度（px）
+const Y_TICK_N = 5; // Y 轴刻度数（含两端）
+const X_TICK_N = 5; // X 轴刻度数（含两端）
 
 function linePath(values: number[], allMin: number, allMax: number): string {
   if (values.length < 2) return "";
@@ -37,44 +41,123 @@ function linePath(values: number[], allMin: number, allMax: number): string {
     .join(" ");
 }
 
+interface PerfTick {
+  value: number;
+  /** viewBox 内 y 坐标（顶 6 → 底 CHART_H-6） */
+  y: number;
+  /** 相对绘图区高度的百分比位置（用于 HTML 标签定位） */
+  pct: number;
+}
+
 function CockpitPerfChart({ perf }: { perf: PortfolioPerformance }) {
-  const { portfolio, benchmark, min, max } = useMemo(() => {
+  const { portfolio, benchmark, min, max, yTicks, xTicks } = useMemo(() => {
     const p = perf.series.map((pt) => pt.portfolio_index);
     const b = perf.series.map((pt) => pt.benchmark_index);
     const all = [...p, ...b];
-    return {
-      portfolio: p,
-      benchmark: b,
-      min: Math.min(...all),
-      max: Math.max(...all),
-    };
+    const lo = Math.min(...all);
+    const hi = Math.max(...all);
+    const span = hi - lo || 1;
+    // Y 刻度：从顶到底均匀取值，与 linePath 的映射保持一致。
+    const yTicks: PerfTick[] = Array.from({ length: Y_TICK_N }, (_, i) => {
+      const r = i / (Y_TICK_N - 1); // 0=顶, 1=底
+      return {
+        value: hi - r * span,
+        y: 6 + r * (CHART_H - 12),
+        pct: ((6 + r * (CHART_H - 12)) / CHART_H) * 100,
+      };
+    });
+    // X 刻度：首、1/4、1/2、3/4、末 对应的日期。
+    const n = perf.series.length;
+    const xTicks =
+      n < 2
+        ? []
+        : Array.from({ length: X_TICK_N }, (_, i) => ({
+            date: perf.series[Math.round((i / (X_TICK_N - 1)) * (n - 1))].date,
+            x: (i / (X_TICK_N - 1)) * CHART_W,
+          }));
+    return { portfolio: p, benchmark: b, min: lo, max: hi, yTicks, xTicks };
   }, [perf.series]);
 
   return (
-    <svg
-      className="cockpit-perf-chart"
-      viewBox={`0 0 ${CHART_W} ${CHART_H}`}
-      preserveAspectRatio="none"
-      role="img"
-      aria-label="portfolio-vs-benchmark"
+    <div
+      className="cockpit-perf-chart-wrap"
+      style={{ paddingLeft: AXIS_Y_W, paddingBottom: AXIS_X_H }}
     >
-      <path
-        d={linePath(benchmark, min, max)}
-        fill="none"
-        stroke="var(--muted)"
-        strokeWidth="1.5"
-        strokeDasharray="4 3"
-        opacity="0.8"
-      />
-      <path
-        d={linePath(portfolio, min, max)}
-        fill="none"
-        stroke="var(--accent)"
-        strokeWidth="2.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
+      <svg
+        className="cockpit-perf-chart"
+        viewBox={`0 0 ${CHART_W} ${CHART_H}`}
+        preserveAspectRatio="none"
+        role="img"
+        aria-label="portfolio-vs-benchmark"
+      >
+        {/* 纵向网格线（X 刻度） */}
+        {xTicks.map((tk) => (
+          <line
+            key={`gx-${tk.x}`}
+            x1={tk.x}
+            y1={6}
+            x2={tk.x}
+            y2={CHART_H - 6}
+            className="cockpit-perf-grid"
+          />
+        ))}
+        {/* 横向网格线（Y 刻度） */}
+        {yTicks.map((tk) => (
+          <line
+            key={`gy-${tk.y}`}
+            x1={0}
+            y1={tk.y}
+            x2={CHART_W}
+            y2={tk.y}
+            className="cockpit-perf-grid"
+          />
+        ))}
+        <path
+          d={linePath(benchmark, min, max)}
+          fill="none"
+          stroke="var(--muted)"
+          strokeWidth="1.5"
+          strokeDasharray="4 3"
+          opacity="0.8"
+        />
+        <path
+          d={linePath(portfolio, min, max)}
+          fill="none"
+          stroke="var(--accent)"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+      {/* Y 轴标签（数值） */}
+      <div
+        className="cockpit-perf-axis-y mono"
+        style={{ width: AXIS_Y_W, bottom: AXIS_X_H }}
+        aria-hidden="true"
+      >
+        {yTicks.map((tk) => (
+          <span key={tk.value} className="cockpit-perf-tick-y" style={{ top: `${tk.pct}%` }}>
+            {tk.value.toFixed(3)}
+          </span>
+        ))}
+      </div>
+      {/* X 轴标签（日期 MM-DD） */}
+      <div
+        className="cockpit-perf-axis-x mono"
+        style={{ left: AXIS_Y_W, height: AXIS_X_H }}
+        aria-hidden="true"
+      >
+        {xTicks.map((tk, i) => (
+          <span
+            key={`${tk.date}-${i}`}
+            className={`cockpit-perf-tick-x ${i === 0 ? "first" : i === xTicks.length - 1 ? "last" : "mid"}`}
+            style={{ left: `${(tk.x / CHART_W) * 100}%` }}
+          >
+            {tk.date.slice(5)}
+          </span>
+        ))}
+      </div>
+    </div>
   );
 }
 

--- a/web/src/styles/app/panels.css
+++ b/web/src/styles/app/panels.css
@@ -4120,6 +4120,53 @@
   padding: 4px 2px;
   box-sizing: border-box;
 }
+.cockpit-perf-chart-wrap {
+  position: relative;
+  box-sizing: border-box;
+}
+.cockpit-perf-grid {
+  stroke: var(--bbg-border, rgba(148, 163, 184, 0.18));
+  stroke-width: 0.8;
+  opacity: 0.7;
+}
+.cockpit-perf-axis-y {
+  position: absolute;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+}
+.cockpit-perf-tick-y {
+  position: absolute;
+  right: 6px;
+  transform: translateY(-50%);
+  font-size: 10px;
+  line-height: 1;
+  color: var(--muted);
+  white-space: nowrap;
+}
+.cockpit-perf-axis-x {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+}
+.cockpit-perf-tick-x {
+  position: absolute;
+  top: 2px;
+  font-size: 10px;
+  line-height: 1;
+  color: var(--muted);
+  white-space: nowrap;
+}
+.cockpit-perf-tick-x.first {
+  transform: translateX(0);
+}
+.cockpit-perf-tick-x.mid {
+  transform: translateX(-50%);
+}
+.cockpit-perf-tick-x.last {
+  transform: translateX(-100%);
+}
 .cockpit-attribution {
   margin-top: 8px;
 }


### PR DESCRIPTION
## 改动内容

净值走势图（组合日线 vs 沪深300）增加横纵坐标轴：

- **Y 轴（净值）**：5 个等分刻度，顶部最大值 → 底部最小值，数值保留 3 位小数
- **X 轴（日期）**：首、1/4、1/2、3/4、末 5 个交易日的 MM-DD 日期刻度
- **网格线**：SVG 内新增纵横网格线辅助读数

## 实现说明

- 坐标轴标签用 HTML 绝对定位叠加在 SVG 外层，避免 `preserveAspectRatio="none"` 拉伸导致文字变形
- 刻度位置与曲线映射（linePath）严格一致
- 样式沿用现有 `--muted` / `--bbg-border` 变量

## 验证

- [x] `tsc --noEmit` 通过
- [x] `npm run build` 通过
- [x] pre-commit 钩子（prettier）通过