### PR TITLE
fix: term 标签泄漏 + 大盘问法自动四维投研

### DIFF
--- a/src/stockresearch/agents/orchestrator/chat_execute.py
+++ b/src/stockresearch/agents/orchestrator/chat_execute.py
@@ -13,6 +13,7 @@ from stockresearch.agents.orchestrator.complexity import (
     is_market_scope,
     is_simple_news_explanation,
     is_trend_explanation_intent,
+    wants_market_research,
 )
 from stockresearch.agents.orchestrator.plan_execute import PlanExecuteAgent
 from stockresearch.agents.orchestrator.react_agent import OrchestratorAgent
@@ -252,6 +253,46 @@ async def _run_plan_execute_sync(ctx: ChatRunContext) -> ChatExecuteResult:
     return ChatExecuteResult(reply=reply, cards=merged, intent=_intent_from_cards(merged))
 
 
+async def _run_market_research_sync(ctx: ChatRunContext) -> ChatExecuteResult:
+    """大盘四维投研：与 Market Tab 大盘深研同一流式实现，事件转发给进度回调。"""
+    from stockresearch.agents.market.research_stream import run_market_research_stream
+    from stockresearch.core.schemas import ResearchReportOut
+
+    payload: dict[str, object] | None = None
+    try:
+        async for event in run_market_research_stream(
+            ctx.message,
+            llm=ctx.llm,  # type: ignore[arg-type]
+            with_debate=ctx.debate_on,
+            mode_settings=ctx.mode_settings,
+        ):
+            if event.get("type") == "done":
+                raw = event.get("result")
+                if isinstance(raw, dict):
+                    payload = raw
+            elif ctx.on_progress:
+                await ctx.on_progress(event)
+    except Exception as exc:
+        logger.warning("[sid=%s] market research failed: %s", ctx.trace_id or "-", exc)
+        return ChatExecuteResult(
+            reply="大盘投研暂时无法完成，请稍后重试。",
+            partial=True,
+            intent="research",
+        )
+    if payload is None:
+        return ChatExecuteResult(
+            reply="大盘投研暂时无法完成，请稍后重试。",
+            partial=True,
+            intent="research",
+        )
+    report = ResearchReportOut.model_validate(payload)
+    return ChatExecuteResult(
+        reply=report.summary,
+        cards=[{"type": "research", "data": payload}],
+        intent="research",
+    )
+
+
 async def _run_react_sync(ctx: ChatRunContext) -> ChatExecuteResult:
     if ctx.on_progress:
         from stockresearch.i18n.status_events import status_event
@@ -270,6 +311,10 @@ async def _run_react_sync(ctx: ChatRunContext) -> ChatExecuteResult:
                 scope=ctx.scope,
                 on_progress=ctx.on_progress,
             )
+        elif wants_market_research(ctx.message):
+            # 大盘"分析性问法"（怎么样/走势/展望/为什么…）→ 直接市场四维投研，
+            # 与 Market Tab 大盘深研同一实现；纯报价问法仍走轻量路径。
+            return await _run_market_research_sync(ctx)
         elif is_trend_explanation_intent(ctx.message):
             run_message = await _augment_trend_message(
                 agent,

--- a/src/stockresearch/agents/orchestrator/complexity.py
+++ b/src/stockresearch/agents/orchestrator/complexity.py
@@ -419,6 +419,32 @@ def is_market_analysis_intent(message: str) -> bool:
     return False
 
 
+# 大盘"分析性问法"关键词：命中即路由到市场四维投研（skill_market_research）。
+_MARKET_ANALYSIS_KW_RE = re.compile(
+    r"(怎么样|如何|怎么看|走势|趋势|分析|研判|展望|前景|后市|方向|机会|风险|影响|"
+    r"涨跌|会涨|会跌|反弹|回调|为什么|为何|原因|点评|解读)"
+)
+# 纯报价问法：只问点位/价格，不需要四维投研。
+_MARKET_QUOTE_RE = re.compile(
+    r"(多少点|点位|报价|现价|指数多少|多少了|多少|价格|涨了多少|跌了多少)"
+)
+
+
+def wants_market_research(message: str) -> bool:
+    """True when the user asks an analytical question about the broad market —
+    route to the 4-dimension market research stream instead of the light
+    quote+news path (which is reserved for spot/quote questions).
+    """
+    msg = message.strip()
+    if not msg or is_news_intent(msg):
+        return False
+    if not is_market_scope(msg):
+        return False
+    if _MARKET_QUOTE_RE.search(msg):
+        return False
+    return bool(_MARKET_ANALYSIS_KW_RE.search(msg))
+
+
 def is_industry_research(message: str) -> bool:
     msg = message.strip()
     if has_stock_reference(msg):

--- a/tests/contracts/test_prd_contracts.py
+++ b/tests/contracts/test_prd_contracts.py
@@ -142,3 +142,28 @@ def test_debate_sync_and_stream_share_judge_format() -> None:
     assert "research_judge_system()" in src
     assert "ResearchJudgeOut.from_llm" in src
     assert "_JUDGE_SYSTEM" not in src
+
+
+def test_market_analysis_queries_route_to_4d_research() -> None:
+    """大盘分析性问法 → 市场四维投研；纯报价问法 → 轻量路径。"""
+    from stockresearch.agents.orchestrator.complexity import wants_market_research as w
+
+    assert w("今天大盘怎么样") is True
+    assert w("A股市场走势如何") is True
+    assert w("大盘为什么涨") is True
+    assert w("上证指数展望") is True
+    assert w("今天大盘多少点") is False
+    assert w("上证指数现在多少") is False
+    assert w("有什么财经新闻") is False
+    assert w("帮我分析一下600519") is False
+
+
+def test_chat_execute_wires_market_research_route() -> None:
+    """chat_execute 必须优先于 trend 轻量路径路由市场四维投研。"""
+    import inspect
+
+    from stockresearch.agents.orchestrator import chat_execute
+
+    src = inspect.getsource(chat_execute._run_react_sync)
+    assert "wants_market_research" in src
+    assert "_run_market_research_sync" in src

--- a/web/src/BriefingHistoryPanel.tsx
+++ b/web/src/BriefingHistoryPanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { api, type Briefing } from "./api";
 import { CollapsibleSection } from "./CollapsibleSection";
 import { useI18n } from "./i18n";
+import { MarkdownContent } from "./MarkdownContent";
 
 const BRIEFING_KINDS: Array<{ kind: Briefing["kind"]; labelKey: string }> = [
   { kind: "premarket", labelKey: "lists.briefingKindPremarket" },
@@ -107,7 +108,9 @@ export function BriefingHistoryPanel() {
                     `lists.briefingKind${b.kind === "premarket" ? "Premarket" : b.kind === "intraday" ? "Intraday" : "Postmarket"}`,
                   )}
                 </span>
-                <span className="briefing-item-title">{b.title || b.summary}</span>
+                <span className="briefing-item-title">
+                  <MarkdownContent text={b.title || b.summary} className="briefing-item-title-md" />
+                </span>
                 <span className="briefing-item-date">{dateKey(b.generated_at)}</span>
               </button>
             </li>
@@ -115,20 +118,31 @@ export function BriefingHistoryPanel() {
         </ul>
         {selected && (
           <div className="briefing-detail">
-            <h4>{selected.title}</h4>
-            {selected.summary && <p className="briefing-summary">{selected.summary}</p>}
+            <h4>
+              <MarkdownContent text={selected.title} className="briefing-title-md" />
+            </h4>
+            {selected.summary && (
+              <MarkdownContent text={selected.summary} className="briefing-summary-md" />
+            )}
             {selected.sections.map((s, i) => (
               <div key={i} className="briefing-section">
-                <strong>{s.title}</strong>
-                <p>{s.content}</p>
+                <strong>
+                  <MarkdownContent text={s.title} className="briefing-section-title-md" />
+                </strong>
+                <MarkdownContent text={s.content} />
               </div>
             ))}
             {morningMatch && (
               <details className="briefing-contrast">
                 <summary>{t("lists.briefingContrast")}</summary>
                 <div className="briefing-section">
-                  <strong>{morningMatch.title}</strong>
-                  <p>{morningMatch.summary}</p>
+                  <strong>
+                    <MarkdownContent
+                      text={morningMatch.title}
+                      className="briefing-section-title-md"
+                    />
+                  </strong>
+                  <MarkdownContent text={morningMatch.summary} />
                 </div>
               </details>
             )}

--- a/web/src/styles/app/panels.css
+++ b/web/src/styles/app/panels.css
@@ -4183,6 +4183,7 @@
   margin: 0 0 4px;
   font-size: 12px;
 }
+.briefing-summary-md,
 .briefing-summary {
   font-size: 12px;
   color: var(--text-secondary);
@@ -4317,4 +4318,14 @@
 .hypothesis-window-n {
   color: var(--text-tertiary);
   font-size: 11px;
+}
+
+/* term 标签在简报容器内与普通文本同尺寸 */
+.briefing-item-title-md,
+.briefing-section-title-md {
+  font-size: inherit;
+}
+.briefing-item-title-md p {
+  margin: 0;
+  display: inline;
 }


### PR DESCRIPTION
本地全量验证通过（677 pytest + 102 前端 + ruff/mypy），真机验证：\n- '今天大盘怎么样' → 四维 agent 触发 + research 卡\n- '上证指数现在多少点' → 轻量路径\n- 简报 <term> 标签改 MarkdownContent 渲染