### PR TITLE
refactor: 风控双实现收敛 + 业务逻辑下沉路由层 + 测试补缺

### DIFF
--- a/src/stockresearch/agents/risk/engine.py
+++ b/src/stockresearch/agents/risk/engine.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from datetime import UTC, datetime
 
 from stockresearch.agents.risk import messages as risk_msg
 from stockresearch.agents.risk.metrics import (
@@ -304,6 +305,49 @@ async def compute_quant_metrics(
         return None, None, []
 
 
+async def _load_quotes_with_placeholders(holdings: list[Holding]) -> tuple[list, list[str]]:
+    """批量拉行情；缺失标的使用成本价占位（保证与持仓对齐，zip 不崩）。
+
+    返回 (quotes, missing_symbols)。engine 与 stream 共用。
+    """
+    if not holdings:
+        return [], []
+    quote_provider = QuoteProvider()
+    quote_map = await quote_provider.get_quotes([h.symbol for h in holdings])
+    quotes: list[Quote] = []
+    missing: list[str] = []
+    for h in holdings:
+        q = quote_map.get(h.symbol)
+        if q is None:
+            missing.append(h.symbol)
+            # Placeholder keeps holdings/quotes aligned so downstream zip never
+            # crashes when a quote provider is temporarily unavailable.
+            q = Quote(
+                symbol=h.symbol,
+                name=h.name or h.symbol,
+                price=float(h.float_cost_price or 0.0),
+                change_pct=0.0,
+                open=0.0,
+                high=0.0,
+                low=0.0,
+                volume=0.0,
+                updated_at=datetime.now(UTC),
+            )
+        quotes.append(q)
+    if missing:
+        logger.warning("Risk checkup missing quotes for: %s", ",".join(missing))
+    return quotes, missing
+
+
+def portfolio_summary_from_alerts(holdings: list[Holding], alerts: list) -> str:
+    """无持仓/无告警/有告警三态组合摘要文案（engine 与 stream 共用）。"""
+    if not holdings:
+        return risk_msg.portfolio_summary_no_holdings()
+    if not alerts:
+        return risk_msg.portfolio_summary_all_clear(len(holdings))
+    return risk_msg.portfolio_summary_with_alerts(len(alerts))
+
+
 async def run_risk_checkup(
     holdings: list[Holding],
     llm: LLMClient | None = None,
@@ -322,11 +366,8 @@ async def run_risk_checkup(
     if enable_llm_analysis is None:
         enable_llm_analysis = True
     client = llm or get_llm_client()
-    quote_provider = QuoteProvider()
 
-    quotes = await asyncio.gather(
-        *[quote_provider.get_quote(holding.symbol) for holding in holdings]
-    )
+    quotes, _missing = await _load_quotes_with_placeholders(holdings)
 
     alerts = _parse_rule_alerts(holdings, quotes)
 
@@ -379,13 +420,7 @@ async def run_risk_checkup(
             alert.human_message = alert.message
         llm_analysis = None
 
-    if not holdings:
-        summary = risk_msg.portfolio_summary_no_holdings()
-    elif not alerts:
-        summary = risk_msg.portfolio_summary_all_clear(len(holdings))
-    else:
-        summary = risk_msg.portfolio_summary_with_alerts(len(alerts))
-
+    summary = portfolio_summary_from_alerts(holdings, alerts)
     # ── 量化风险指标 ──
     metrics_out, var_out, stress_out = await compute_quant_metrics(holdings, quotes)
 

--- a/src/stockresearch/agents/risk/stream.py
+++ b/src/stockresearch/agents/risk/stream.py
@@ -3,7 +3,6 @@
 import asyncio
 import logging
 from collections.abc import AsyncIterator
-from datetime import UTC, datetime
 
 from stockresearch.agents.research.debate import (
     iter_triangular_debate_events,
@@ -14,8 +13,10 @@ from stockresearch.agents.risk.engine import (
     _llm_correlation_analysis,
     _llm_market_assessment,
     _llm_scenario_analysis,
+    _load_quotes_with_placeholders,
     _parse_rule_alerts,
     compute_quant_metrics,
+    portfolio_summary_from_alerts,
     run_risk_checkup,
 )
 from stockresearch.agents.risk.judge import (
@@ -37,8 +38,6 @@ from stockresearch.core.schemas import (
     RiskAlertOut,
     RiskCheckupOut,
 )
-from stockresearch.data.providers.market import QuoteProvider
-from stockresearch.data.providers.market.common import Quote
 from stockresearch.db.models import Holding
 from stockresearch.i18n.status_events import status_event
 from stockresearch.services.compliance_language import (
@@ -137,30 +136,7 @@ async def run_risk_checkup_stream(
         "agent_name": "规则引擎",
         "role": "rules",
     }
-    quote_provider = QuoteProvider()
-    quote_map = await quote_provider.get_quotes([h.symbol for h in holdings]) if holdings else {}
-    quotes: list[Quote] = []
-    missing: list[str] = []
-    for h in holdings:
-        q = quote_map.get(h.symbol)
-        if q is None:
-            missing.append(h.symbol)
-            # Placeholder keeps holdings/quotes aligned so downstream zip never
-            # crashes when a quote provider is temporarily unavailable.
-            q = Quote(
-                symbol=h.symbol,
-                name=h.name or h.symbol,
-                price=float(h.float_cost_price or 0.0),
-                change_pct=0.0,
-                open=0.0,
-                high=0.0,
-                low=0.0,
-                volume=0.0,
-                updated_at=datetime.now(UTC),
-            )
-        quotes.append(q)
-    if missing:
-        logger.warning("Risk checkup missing quotes for: %s", ",".join(missing))
+    quotes, missing = await _load_quotes_with_placeholders(holdings)
 
     alerts = _parse_rule_alerts(holdings, quotes)
     for alert in alerts:
@@ -197,10 +173,7 @@ async def run_risk_checkup_stream(
 
     # PRD §四 可选 LLM：关闭时跳过 parallel agents / debate / manager / judge
     if not enable_llm_analysis:
-        if not alerts:
-            summary = risk_msg.portfolio_summary_all_clear(len(holdings))
-        else:
-            summary = risk_msg.portfolio_summary_with_alerts(len(alerts))
+        summary = portfolio_summary_from_alerts(holdings, alerts)
         result = RiskCheckupOut(
             alerts=alerts,
             portfolio_summary=summary,

--- a/src/stockresearch/api/routes/chat.py
+++ b/src/stockresearch/api/routes/chat.py
@@ -11,17 +11,17 @@ from stockresearch.agents.orchestrator.stream import run_chat_stream
 from stockresearch.api.deps import get_current_user
 from stockresearch.api.llm_deps import resolve_llm_client
 from stockresearch.api.rate_limit import limiter
-from stockresearch.api.routes.research import (
-    attach_report_ids_to_cards,
-    extract_reports_from_cards,
-    persist_report,
-)
 from stockresearch.api.sse import sse_response
 from stockresearch.core.exceptions import NotFoundError
 from stockresearch.core.output_style import output_style_scope
 from stockresearch.core.schemas import ChatRequest, ChatResponse, StreamCheckpointOut
 from stockresearch.db.models import User
 from stockresearch.db.session import get_db
+from stockresearch.services.research_persistence import (
+    attach_report_ids_to_cards,
+    extract_reports_from_cards,
+    persist_report,
+)
 from stockresearch.services.stream_checkpoint import load_checkpoint
 from stockresearch.services.user_preferences import get_mode_settings
 

--- a/src/stockresearch/api/routes/portfolio.py
+++ b/src/stockresearch/api/routes/portfolio.py
@@ -1,7 +1,6 @@
 """Holdings and watchlist routes."""
 
-from datetime import UTC, date, datetime
-from decimal import Decimal
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
@@ -19,7 +18,6 @@ from stockresearch.core.schemas import (
     HoldingEnrichedOut,
     HoldingOut,
     HoldingTransactionBatch,
-    HoldingTransactionItem,
     HoldingTransactionResult,
     PortfolioEventsOut,
     PortfolioOptimizeOut,
@@ -56,166 +54,18 @@ from stockresearch.services.provider_cache_policy import quote_cache_ttl_seconds
 from stockresearch.services.screener import run_screen
 from stockresearch.services.stock_lookup import lookup_stock
 from stockresearch.services.stock_sector import backfill_holding_sectors, resolve_stock_sector
-from stockresearch.services.symbol_resolver import resolve_stock_query
+from stockresearch.services.trade_ledger import (
+    LOTS_SIZE,
+    record_trade,
+    resolve_holding,
+    resolve_transaction_symbol_name,
+    sell_holding,
+    upsert_holding,
+)
 from stockresearch.services.user_preferences import get_mode_settings
 from stockresearch.utils.llm import get_llm_client
 
 router = APIRouter(prefix="/portfolio", tags=["portfolio"])
-
-LOTS_SIZE = 100
-
-
-def _latest_report_id(db: Session, user_id: int, symbol: str) -> int | None:
-    """Attach the most recent research report for the symbol (decision journal)."""
-    report = (
-        db.query(ResearchReport)
-        .filter(
-            ResearchReport.symbol == symbol,
-            (ResearchReport.user_id == user_id) | (ResearchReport.user_id.is_(None)),
-        )
-        .order_by(ResearchReport.created_at.desc(), ResearchReport.id.desc())
-        .first()
-    )
-    return report.id if report else None
-
-
-def _record_trade(
-    db: Session,
-    *,
-    user_id: int,
-    symbol: str,
-    name: str,
-    side: str,
-    price: float,
-    quantity: int,
-    trade_date: date | None = None,
-    realized_pnl: float | None = None,
-    note: str | None = None,
-    commit: bool = False,
-) -> Trade:
-    trade = Trade(
-        user_id=user_id,
-        symbol=symbol,
-        name=name,
-        side=side,
-        price=price,
-        quantity=quantity,
-        trade_date=trade_date,
-        realized_pnl=None if realized_pnl is None else round(realized_pnl, 2),
-        note=(note.strip() or None) if note else None,
-        report_id=_latest_report_id(db, user_id, symbol),
-    )
-    db.add(trade)
-    if commit:
-        db.commit()
-    else:
-        db.flush()
-    return trade
-
-
-def _upsert_holding(
-    db: Session,
-    *,
-    user_id: int,
-    symbol: str,
-    name: str,
-    cost_price: float,
-    quantity: int,
-    sector: str | None = None,
-    buy_date: date | None = None,
-    commit: bool = True,
-) -> Holding:
-    existing = (
-        db.query(Holding).filter(Holding.user_id == user_id, Holding.symbol == symbol).first()
-    )
-    if existing is not None:
-        total_qty = existing.quantity + quantity
-        existing.cost_price = Decimal(
-            (float(existing.cost_price) * existing.quantity + cost_price * quantity) / total_qty
-        )
-        existing.quantity = total_qty
-        existing.name = name
-        if sector:
-            existing.sector = sector
-        if commit:
-            db.commit()
-            db.refresh(existing)
-        else:
-            db.flush()
-        return existing
-
-    holding = Holding(
-        user_id=user_id,
-        symbol=symbol,
-        name=name,
-        cost_price=cost_price,
-        quantity=quantity,
-        sector=sector or "未知",
-        buy_date=buy_date,
-    )
-    db.add(holding)
-    if commit:
-        db.commit()
-        db.refresh(holding)
-    else:
-        db.flush()
-    return holding
-
-
-def _sell_holding(
-    db: Session,
-    *,
-    user_id: int,
-    symbol: str,
-    quantity: int,
-    name: str | None = None,
-    commit: bool = True,
-) -> None:
-    holding = db.query(Holding).filter(Holding.user_id == user_id, Holding.symbol == symbol).first()
-    label = name or (holding.name if holding else symbol)
-    if holding is None or holding.quantity < quantity:
-        available = holding.quantity if holding else 0
-        raise ValidationError(f"{label} 卖出数量超出持仓（当前 {available} 股）")
-    holding.quantity -= quantity
-    if holding.quantity == 0:
-        db.delete(holding)
-    if commit:
-        db.commit()
-    else:
-        db.flush()
-
-
-async def _resolve_transaction_symbol_name(
-    item: HoldingTransactionItem,
-) -> tuple[str, str, str | None]:
-    if item.symbol and item.name:
-        sector = await resolve_stock_sector(item.symbol, item.name)
-        return item.symbol, item.name, sector
-    if item.symbol and not item.name:
-        _, name = resolve_stock_query(item.symbol)
-        sector = await resolve_stock_sector(item.symbol, name)
-        return item.symbol, name, sector
-    query = item.query or item.name
-    if not query:
-        raise ValidationError("请提供股票代码或名称")
-    lookup = await lookup_stock(query, llm=get_llm_client())
-    if lookup.status != "confirmed" or not lookup.symbol or not lookup.name:
-        raise ValidationError(lookup.message or f"无法识别股票：{query}")
-    sector = await resolve_stock_sector(lookup.symbol, lookup.name)
-    return lookup.symbol, lookup.name, sector
-
-
-def _resolve_holding(payload: HoldingCreate) -> tuple[str, str]:
-    if payload.symbol and payload.name:
-        return payload.symbol, payload.name
-    if payload.symbol and not payload.name:
-        _, name = resolve_stock_query(payload.symbol)
-        return payload.symbol, name
-    if payload.query:
-        return resolve_stock_query(payload.query)
-    if payload.name and not payload.symbol:
-        return resolve_stock_query(payload.name)
-    raise ValidationError("请提供股票代码或名称")
 
 
 @router.post("/holdings/lookup", response_model=StockLookupOut)
@@ -308,7 +158,7 @@ async def create_holding(
                 raise ValidationError(lookup.message)
             symbol, name = lookup.symbol, lookup.name
         else:
-            symbol, name = _resolve_holding(payload)
+            symbol, name = resolve_holding(payload)
     except ValidationError as exc:
         # 直接上抛交给全局 handler（统一 code 字段契约）
         raise exc
@@ -320,7 +170,7 @@ async def create_holding(
     if not sector or sector == "未知":
         sector = await resolve_stock_sector(symbol, name)
 
-    holding = _upsert_holding(
+    holding = upsert_holding(
         db,
         user_id=user.id,
         symbol=symbol,
@@ -331,7 +181,7 @@ async def create_holding(
         buy_date=payload.buy_date,
         commit=False,
     )
-    _record_trade(
+    record_trade(
         db,
         user_id=user.id,
         symbol=symbol,
@@ -356,14 +206,14 @@ async def apply_holding_transactions(
     try:
         resolved: list[tuple] = []
         for item in payload.transactions:
-            symbol, name, sector = await _resolve_transaction_symbol_name(item)
+            symbol, name, sector = await resolve_transaction_symbol_name(item)
             resolved.append((item, symbol, name, sector))
 
         for item, symbol, name, sector in resolved:
             quantity = item.lots * LOTS_SIZE
             if item.side == "buy":
                 assert item.cost_price is not None
-                _upsert_holding(
+                upsert_holding(
                     db,
                     user_id=user.id,
                     symbol=symbol,
@@ -374,7 +224,7 @@ async def apply_holding_transactions(
                     buy_date=item.trade_date,
                     commit=False,
                 )
-                _record_trade(
+                record_trade(
                     db,
                     user_id=user.id,
                     symbol=symbol,
@@ -392,7 +242,7 @@ async def apply_holding_transactions(
                     .first()
                 )
                 avg_cost = existing.float_cost_price if existing else None
-                _sell_holding(
+                sell_holding(
                     db,
                     user_id=user.id,
                     symbol=symbol,
@@ -406,7 +256,7 @@ async def apply_holding_transactions(
                         if avg_cost is not None
                         else None
                     )
-                    _record_trade(
+                    record_trade(
                         db,
                         user_id=user.id,
                         symbol=symbol,
@@ -440,7 +290,7 @@ async def confirm_holding(
     sector = payload.sector
     if not sector or sector == "未知":
         sector = await resolve_stock_sector(payload.symbol, payload.name)
-    holding = _upsert_holding(
+    holding = upsert_holding(
         db,
         user_id=user.id,
         symbol=payload.symbol,
@@ -451,7 +301,7 @@ async def confirm_holding(
         buy_date=payload.buy_date,
         commit=False,
     )
-    _record_trade(
+    record_trade(
         db,
         user_id=user.id,
         symbol=payload.symbol,

--- a/src/stockresearch/api/routes/research.py
+++ b/src/stockresearch/api/routes/research.py
@@ -60,6 +60,11 @@ from stockresearch.services.report_export import (
     report_to_pdf,
 )
 from stockresearch.services.research_memory import search_research_memory
+from stockresearch.services.research_persistence import (
+    persist_report,
+    register_cached_report,
+    stamp_report_id,
+)
 from stockresearch.services.research_timeline import compute_research_timeline
 from stockresearch.services.signal_backtest import compute_report_post_hoc, compute_signal_backtest
 from stockresearch.services.user_preferences import get_mode_settings
@@ -116,107 +121,6 @@ async def _enrich_regime(db: Session, report_id: int | None) -> None:
         logger.debug("regime enrichment skipped", exc_info=True)
 
 
-def persist_report(db: Session, user_id: int, report: ResearchReportOut) -> ResearchReport:
-    payload = report.model_dump(mode="json")
-    row = ResearchReport(
-        user_id=user_id,
-        symbol=report.symbol,
-        name=report.name,
-        report_json=payload,
-    )
-    db.add(row)
-    db.commit()
-    db.refresh(row)
-    payload["id"] = row.id
-    row.report_json = payload
-    db.add(row)
-    db.commit()
-    db.refresh(row)
-    register_report_verifications(db, user_id, report, report_id=row.id)
-    return row
-
-
-def register_report_verifications(
-    db: Session,
-    user_id: int,
-    report: ResearchReportOut,
-    *,
-    report_id: int | None,
-) -> None:
-    """登记预测日记/Thesis 验证（幂等）。缓存命中路径也须调用，避免缺样本。"""
-    # Phase 12a 预测日记：研报事实层自动留存预测记录（幂等）。
-    try:
-        from stockresearch.services.prediction_journal import record_prediction_for_report
-
-        record_prediction_for_report(db, user_id, report, report_id=report_id)
-    except Exception:
-        logger.warning("prediction record failed for %s", report.symbol, exc_info=True)
-    # Phase 12e 假设自动验证：deep 档 Thesis 自动创建验证计划（幂等）。
-    try:
-        from stockresearch.services.thesis_verification import record_thesis_for_report
-
-        record_thesis_for_report(db, user_id, report, report_id=report_id)
-    except Exception:
-        logger.warning("thesis verification record failed for %s", report.symbol, exc_info=True)
-
-
-def stamp_report_id(report: ResearchReportOut, report_id: int) -> ResearchReportOut:
-    return report.model_copy(update={"id": report_id})
-
-
-def attach_report_ids_to_cards(
-    cards: list[dict[str, object]],
-    id_by_symbol: dict[str, int],
-) -> list[dict[str, object]]:
-    updated: list[dict[str, object]] = []
-    for card in cards:
-        if card.get("type") != "research":
-            updated.append(card)
-            continue
-        data = card.get("data")
-        if not isinstance(data, dict):
-            updated.append(card)
-            continue
-        symbol = str(data.get("symbol", ""))
-        report_id = id_by_symbol.get(symbol)
-        if report_id is None:
-            updated.append(card)
-            continue
-        marked = dict(data)
-        marked["id"] = report_id
-        updated.append({**card, "data": marked})
-    return updated
-
-
-def extract_reports_from_cards(cards: list[dict[str, object]]) -> list[ResearchReportOut]:
-    reports: list[ResearchReportOut] = []
-    for card in cards:
-        if card.get("type") != "research":
-            continue
-        data = card.get("data")
-        if isinstance(data, dict):
-            reports.append(ResearchReportOut.model_validate(data))
-    return reports
-
-
-def _register_cached_report(db: Session, user_id: int, report: ResearchReportOut) -> int | None:
-    """缓存命中时登记预测/Thesis：复用该用户该标的最近报告行（幂等）。
-
-    缓存 payload 不含 id（persist 时回写的是 DB 行），因此按 (user, symbol)
-    找最近一份报告登记；找不到则新建一行（保证预测日记不因缓存缺样本）。
-    """
-    row = (
-        db.query(ResearchReport)
-        .filter(ResearchReport.user_id == user_id, ResearchReport.symbol == report.symbol)
-        .order_by(ResearchReport.created_at.desc())
-        .first()
-    )
-    if row is not None:
-        register_report_verifications(db, user_id, report, report_id=row.id)
-        return row.id
-    return persist_report(db, user_id, report).id
-
-
 @router.get("/analyze", response_model=ResearchReportOut)
 async def analyze_stock(
     symbol: str = Query(min_length=6, max_length=6, pattern=r"^\d{6}$"),
@@ -235,7 +139,7 @@ async def analyze_stock(
     cached = cache.get_json(cache_key)
     if cached:
         report = ResearchReportOut.model_validate({**cached, "cached": True})
-        report_id = _register_cached_report(db, user.id, report)
+        report_id = register_cached_report(db, user.id, report)
         with output_style_scope(
             reading_mode=settings.reading_mode,
             enable_glossary=settings.enable_glossary,
@@ -274,7 +178,7 @@ async def analyze_stock_stream(
         cached = cache.get_json(cache_key)
         if cached:
             report = ResearchReportOut.model_validate({**cached, "cached": True})
-            report_id = _register_cached_report(db, user.id, report)
+            report_id = register_cached_report(db, user.id, report)
             with output_style_scope(
                 reading_mode=settings.reading_mode,
                 enable_glossary=settings.enable_glossary,

--- a/src/stockresearch/api/routes/risk.py
+++ b/src/stockresearch/api/routes/risk.py
@@ -26,24 +26,11 @@ from stockresearch.core.schemas import (
 from stockresearch.db.models import Holding, RiskAlertRecord, User
 from stockresearch.db.session import get_db
 from stockresearch.services.glossary import mark_terms, merge_glossary
+from stockresearch.services.risk_persistence import persist_alerts
 from stockresearch.services.user_preferences import get_mode_settings
 from stockresearch.utils.llm import LLMClient
 
 router = APIRouter(prefix="/risk", tags=["risk"])
-
-
-def _persist_alerts(db: Session, user_id: int, result: RiskCheckupOut) -> None:
-    for alert in result.alerts:
-        db.add(
-            RiskAlertRecord(
-                user_id=user_id,
-                rule_id=alert.rule_id,
-                severity=alert.severity,
-                symbol=alert.symbol,
-                message=alert.message,
-            )
-        )
-    db.commit()
 
 
 def _mark_text(text: str) -> str:
@@ -133,7 +120,7 @@ async def risk_checkup(
             enable_llm_analysis=_llm_analysis_on(payload),
             mode_settings=settings,
         )
-        _persist_alerts(db, user.id, result)
+        persist_alerts(db, user.id, result)
         # 返回层词库标注（不污染 DB 原文）
         result = _mark_risk_result(result)
     return result
@@ -165,7 +152,7 @@ async def risk_checkup_stream(
                     if isinstance(payload_data, dict):
                         # 在 yield done 之前落库：客户端收到 done 即断连时告警不丢
                         final = RiskCheckupOut.model_validate(payload_data)
-                        _persist_alerts(db, user.id, final)
+                        persist_alerts(db, user.id, final)
                 yield event
 
     return sse_response(event_generator(), keep_alive_seconds=15.0)

--- a/src/stockresearch/services/research_persistence.py
+++ b/src/stockresearch/services/research_persistence.py
@@ -1,0 +1,113 @@
+"""研报持久化与验证登记（从 API 路由层下沉，脱离 HTTP 可复用/可测）。"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy.orm import Session
+
+from stockresearch.core.schemas import ResearchReportOut
+from stockresearch.db.models import ResearchReport
+
+logger = logging.getLogger(__name__)
+
+
+def persist_report(db: Session, user_id: int, report: ResearchReportOut) -> ResearchReport:
+    payload = report.model_dump(mode="json")
+    row = ResearchReport(
+        user_id=user_id,
+        symbol=report.symbol,
+        name=report.name,
+        report_json=payload,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    payload["id"] = row.id
+    row.report_json = payload
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    register_report_verifications(db, user_id, report, report_id=row.id)
+    return row
+
+
+def register_report_verifications(
+    db: Session,
+    user_id: int,
+    report: ResearchReportOut,
+    *,
+    report_id: int | None,
+) -> None:
+    """登记预测日记/Thesis 验证（幂等）。缓存命中路径也须调用，避免缺样本。"""
+    # Phase 12a 预测日记：研报事实层自动留存预测记录（幂等）。
+    try:
+        from stockresearch.services.prediction_journal import record_prediction_for_report
+
+        record_prediction_for_report(db, user_id, report, report_id=report_id)
+    except Exception:
+        logger.warning("prediction record failed for %s", report.symbol, exc_info=True)
+    # Phase 12e 假设自动验证：deep 档 Thesis 自动创建验证计划（幂等）。
+    try:
+        from stockresearch.services.thesis_verification import record_thesis_for_report
+
+        record_thesis_for_report(db, user_id, report, report_id=report_id)
+    except Exception:
+        logger.warning("thesis verification record failed for %s", report.symbol, exc_info=True)
+
+
+def register_cached_report(db: Session, user_id: int, report: ResearchReportOut) -> int | None:
+    """缓存命中时登记预测/Thesis：复用该用户该标的最近报告行（幂等）。
+
+    缓存 payload 不含 id（persist 时回写的是 DB 行），因此按 (user, symbol)
+    找最近一份报告登记；找不到则新建一行（保证预测日记不因缓存缺样本）。
+    """
+    row = (
+        db.query(ResearchReport)
+        .filter(ResearchReport.user_id == user_id, ResearchReport.symbol == report.symbol)
+        .order_by(ResearchReport.created_at.desc())
+        .first()
+    )
+    if row is not None:
+        register_report_verifications(db, user_id, report, report_id=row.id)
+        return row.id
+    return persist_report(db, user_id, report).id
+
+
+def stamp_report_id(report: ResearchReportOut, report_id: int) -> ResearchReportOut:
+    return report.model_copy(update={"id": report_id})
+
+
+def attach_report_ids_to_cards(
+    cards: list[dict[str, object]],
+    id_by_symbol: dict[str, int],
+) -> list[dict[str, object]]:
+    updated: list[dict[str, object]] = []
+    for card in cards:
+        if card.get("type") != "research":
+            updated.append(card)
+            continue
+        data = card.get("data")
+        if not isinstance(data, dict):
+            updated.append(card)
+            continue
+        symbol = str(data.get("symbol", ""))
+        report_id = id_by_symbol.get(symbol)
+        if report_id is None:
+            updated.append(card)
+            continue
+        marked = dict(data)
+        marked["id"] = report_id
+        updated.append({**card, "data": marked})
+    return updated
+
+
+def extract_reports_from_cards(cards: list[dict[str, object]]) -> list[ResearchReportOut]:
+    reports: list[ResearchReportOut] = []
+    for card in cards:
+        if card.get("type") != "research":
+            continue
+        data = card.get("data")
+        if isinstance(data, dict):
+            reports.append(ResearchReportOut.model_validate(data))
+    return reports

--- a/src/stockresearch/services/risk_persistence.py
+++ b/src/stockresearch/services/risk_persistence.py
@@ -1,0 +1,22 @@
+"""风控告警持久化（从 API 路由层下沉，脱离 HTTP 可复用/可测）。"""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from stockresearch.core.schemas import RiskCheckupOut
+from stockresearch.db.models import RiskAlertRecord
+
+
+def persist_alerts(db: Session, user_id: int, result: RiskCheckupOut) -> None:
+    for alert in result.alerts:
+        db.add(
+            RiskAlertRecord(
+                user_id=user_id,
+                rule_id=alert.rule_id,
+                severity=alert.severity,
+                symbol=alert.symbol,
+                message=alert.message,
+            )
+        )
+    db.commit()

--- a/src/stockresearch/services/trade_ledger.py
+++ b/src/stockresearch/services/trade_ledger.py
@@ -1,0 +1,171 @@
+"""持仓与交易台账核心业务逻辑（从 API 路由层下沉，脱离 HTTP 可复用/可测）。"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from sqlalchemy.orm import Session
+
+from stockresearch.core.exceptions import ValidationError
+from stockresearch.core.schemas import HoldingCreate, HoldingTransactionItem
+from stockresearch.db.models import Holding, ResearchReport, Trade
+from stockresearch.services.stock_lookup import lookup_stock
+from stockresearch.services.stock_sector import resolve_stock_sector
+from stockresearch.services.symbol_resolver import resolve_stock_query
+from stockresearch.utils.llm import get_llm_client
+
+LOTS_SIZE = 100
+
+
+def latest_report_id(db: Session, user_id: int, symbol: str) -> int | None:
+    """Attach the most recent research report for the symbol (decision journal)."""
+    report = (
+        db.query(ResearchReport)
+        .filter(
+            ResearchReport.symbol == symbol,
+            (ResearchReport.user_id == user_id) | (ResearchReport.user_id.is_(None)),
+        )
+        .order_by(ResearchReport.created_at.desc(), ResearchReport.id.desc())
+        .first()
+    )
+    return report.id if report else None
+
+
+def record_trade(
+    db: Session,
+    *,
+    user_id: int,
+    symbol: str,
+    name: str,
+    side: str,
+    price: float,
+    quantity: int,
+    trade_date: date | None = None,
+    realized_pnl: float | None = None,
+    note: str | None = None,
+    commit: bool = False,
+) -> Trade:
+    trade = Trade(
+        user_id=user_id,
+        symbol=symbol,
+        name=name,
+        side=side,
+        price=price,
+        quantity=quantity,
+        trade_date=trade_date,
+        realized_pnl=None if realized_pnl is None else round(realized_pnl, 2),
+        note=(note.strip() or None) if note else None,
+        report_id=latest_report_id(db, user_id, symbol),
+    )
+    db.add(trade)
+    if commit:
+        db.commit()
+    else:
+        db.flush()
+    return trade
+
+
+def upsert_holding(
+    db: Session,
+    *,
+    user_id: int,
+    symbol: str,
+    name: str,
+    cost_price: float,
+    quantity: int,
+    sector: str | None = None,
+    buy_date: date | None = None,
+    commit: bool = True,
+) -> Holding:
+    existing = (
+        db.query(Holding).filter(Holding.user_id == user_id, Holding.symbol == symbol).first()
+    )
+    if existing is not None:
+        total_qty = existing.quantity + quantity
+        existing.cost_price = Decimal(
+            (float(existing.cost_price) * existing.quantity + cost_price * quantity) / total_qty
+        )
+        existing.quantity = total_qty
+        existing.name = name
+        if sector:
+            existing.sector = sector
+        if commit:
+            db.commit()
+            db.refresh(existing)
+        else:
+            db.flush()
+        return existing
+
+    holding = Holding(
+        user_id=user_id,
+        symbol=symbol,
+        name=name,
+        cost_price=cost_price,
+        quantity=quantity,
+        sector=sector or "未知",
+        buy_date=buy_date,
+    )
+    db.add(holding)
+    if commit:
+        db.commit()
+        db.refresh(holding)
+    else:
+        db.flush()
+    return holding
+
+
+def sell_holding(
+    db: Session,
+    *,
+    user_id: int,
+    symbol: str,
+    quantity: int,
+    name: str | None = None,
+    commit: bool = True,
+) -> None:
+    holding = db.query(Holding).filter(Holding.user_id == user_id, Holding.symbol == symbol).first()
+    label = name or (holding.name if holding else symbol)
+    if holding is None or holding.quantity < quantity:
+        available = holding.quantity if holding else 0
+        raise ValidationError(f"{label} 卖出数量超出持仓（当前 {available} 股）")
+    holding.quantity -= quantity
+    if holding.quantity == 0:
+        db.delete(holding)
+    if commit:
+        db.commit()
+    else:
+        db.flush()
+
+
+async def resolve_transaction_symbol_name(
+    item: HoldingTransactionItem,
+) -> tuple[str, str, str | None]:
+    if item.symbol and item.name:
+        sector = await resolve_stock_sector(item.symbol, item.name)
+        return item.symbol, item.name, sector
+    if item.symbol and not item.name:
+        _, name = resolve_stock_query(item.symbol)
+        sector = await resolve_stock_sector(item.symbol, name)
+        return item.symbol, name, sector
+    query = item.query or item.name
+    if not query:
+        raise ValidationError("请提供股票代码或名称")
+    lookup = await lookup_stock(query, llm=get_llm_client())
+    if lookup.status != "confirmed" or not lookup.symbol or not lookup.name:
+        raise ValidationError(lookup.message or f"无法识别股票：{query}")
+    sector = await resolve_stock_sector(lookup.symbol, lookup.name)
+    return lookup.symbol, lookup.name, sector
+
+
+def resolve_holding(payload: HoldingCreate) -> tuple[str, str]:
+    if payload.symbol and payload.name:
+        return payload.symbol, payload.name
+    if payload.symbol and not payload.name:
+        _, name = resolve_stock_query(payload.symbol)
+        return payload.symbol, name
+    if payload.query:
+        return resolve_stock_query(payload.query)
+    if payload.name and not payload.symbol:
+        return resolve_stock_query(payload.name)
+    raise ValidationError("请提供股票代码或名称")

--- a/tests/contracts/test_prd_contracts.py
+++ b/tests/contracts/test_prd_contracts.py
@@ -173,11 +173,11 @@ def test_predictions_persist_on_report_save() -> None:
     """Phase 12a：研报持久化必须自动留存预测记录（幂等）。"""
     import inspect
 
-    from stockresearch.api.routes import research
+    from stockresearch.services import research_persistence
 
-    src = inspect.getsource(research.persist_report)
+    src = inspect.getsource(research_persistence.persist_report)
     assert "register_report_verifications" in src
-    src2 = inspect.getsource(research.register_report_verifications)
+    src2 = inspect.getsource(research_persistence.register_report_verifications)
     assert "record_prediction_for_report" in src2
 
 

--- a/tests/services/test_market_regime.py
+++ b/tests/services/test_market_regime.py
@@ -1,0 +1,48 @@
+"""Phase 12f Market Regime — 纯规则判定单元测试。"""
+
+from stockresearch.services.market_regime import (
+    _daily_returns,
+    compute_regime,
+    regime_label,
+)
+
+
+def test_compute_regime_trend_up() -> None:
+    # 25 根单调上行，20d 动量 >> 4%
+    closes = [100.0 + i * 1.0 for i in range(30)]
+    assert compute_regime(closes) == "trend_up"
+
+
+def test_compute_regime_trend_down() -> None:
+    closes = [100.0 - i * 1.0 for i in range(30)]
+    assert compute_regime(closes) == "trend_down"
+
+
+def test_compute_regime_choppy() -> None:
+    # 20d 动量接近 0，震荡
+    closes = [100.0 + (1.5 if i % 2 else -1.5) for i in range(30)]
+    assert compute_regime(closes) == "choppy"
+
+
+def test_compute_regime_insufficient_data() -> None:
+    assert compute_regime([100.0, 101.0]) == "unknown"
+    assert compute_regime([]) == "unknown"
+
+
+def test_compute_regime_zero_start() -> None:
+    # 倒数第 21 根（动量窗口起点）为 0 → 无法算动量，unknown
+    closes = [0.0] * 21 + [100.0] * 9
+    assert compute_regime(closes) == "unknown"
+
+
+def test_regime_label_all() -> None:
+    assert regime_label("trend_up") == "趋势上行"
+    assert regime_label("trend_down") == "趋势下行"
+    assert regime_label("choppy") == "震荡"
+    assert regime_label("unknown") == "未知"
+
+
+def test_daily_returns_skips_zero_prev() -> None:
+    # prev=0 的跳空日不参与收益率（避免除零）
+    returns = _daily_returns([100.0, 101.0, 0.0, 99.0])
+    assert returns == [1.0, -100.0]

--- a/tests/services/test_portfolio_performance.py
+++ b/tests/services/test_portfolio_performance.py
@@ -1,0 +1,107 @@
+"""Portfolio performance — 纯函数单元测试（重建净值/数量序列/归因）。"""
+
+from datetime import date, datetime
+
+from stockresearch.db.models import Trade
+from stockresearch.services.portfolio_performance import (
+    _build_attribution,
+    _quantity_series,
+    _realized_total,
+)
+
+
+def _trade(
+    side: str,
+    quantity: int,
+    price: float = 100.0,
+    trade_date: str | None = "2024-01-15",
+    realized: float | None = None,
+    trade_id: int = 1,
+) -> Trade:
+    t = Trade(
+        user_id=1,
+        symbol="600519",
+        name="贵州茅台",
+        side=side,
+        price=price,
+        quantity=quantity,
+        trade_date=date.fromisoformat(trade_date) if trade_date else None,
+    )
+    t.id = trade_id
+    if realized is not None:
+        t.realized_pnl = realized
+    return t
+
+
+def test_realized_total_sums_only_realized() -> None:
+    trades = [
+        _trade("sell", 100, realized=123.45, trade_id=1),
+        _trade("buy", 100, trade_id=2),
+        _trade("sell", 100, realized=-50.0, trade_id=3),
+    ]
+    assert _realized_total(trades) == 73.45
+
+
+def test_quantity_series_replays_ledger() -> None:
+    dates = [date(2024, 1, 1), date(2024, 1, 10), date(2024, 1, 20), date(2024, 1, 30)]
+    trades = [
+        _trade("buy", 100, trade_date="2024-01-05", trade_id=1),
+        _trade("buy", 200, trade_date="2024-01-15", trade_id=2),
+        _trade("sell", 100, trade_date="2024-01-25", trade_id=3),
+    ]
+    series, approximated = _quantity_series(trades, current_qty=200, dates=dates)
+    assert not approximated
+    assert series[date(2024, 1, 1)] == 0
+    assert series[date(2024, 1, 10)] == 100
+    assert series[date(2024, 1, 20)] == 300
+    assert series[date(2024, 1, 30)] == 200
+
+
+def test_quantity_series_without_ledger_approximates() -> None:
+    dates = [date(2024, 1, 1), date(2024, 1, 30)]
+    series, approximated = _quantity_series([], current_qty=500, dates=dates)
+    assert approximated
+    assert all(q == 500 for q in series.values())
+
+
+def test_quantity_series_trades_without_dates() -> None:
+    dates = [date(2024, 1, 1), date(2024, 1, 30)]
+    t = _trade("buy", 100, trade_date=None, trade_id=1)
+    t.created_at = datetime(2024, 1, 15, 10, 0)
+    series, approximated = _quantity_series([t], current_qty=100, dates=dates)
+    assert not approximated
+    assert series[date(2024, 1, 1)] == 0
+    assert series[date(2024, 1, 30)] == 100
+
+
+class _H:
+    def __init__(self, symbol: str, name: str):
+        self.symbol = symbol
+        self.name = name
+
+
+def test_build_attribution_contributions() -> None:
+    holdings = [_H("600519", "茅台"), _H("000858", "五粮液"), _H("600000", "无日线")]
+    common = [date(2024, 1, 1), date(2024, 1, 2), date(2024, 1, 3)]
+    qty_series = {
+        "600519": {d: 100 for d in common},
+        "000858": {d: 100 for d in common},
+    }
+    closes = {
+        "600519": {date(2024, 1, 1): 100.0, date(2024, 1, 2): 100.0, date(2024, 1, 3): 110.0},
+        "000858": {date(2024, 1, 1): 100.0, date(2024, 1, 2): 100.0, date(2024, 1, 3): 90.0},
+    }
+    items = _build_attribution(holdings, qty_series=qty_series, closes=closes, common=common)
+    by_symbol = {i.symbol: i for i in items}
+    assert by_symbol["600519"].return_pct == 10.0
+    assert by_symbol["000858"].return_pct == -10.0
+    # 权重按逐日市值平均：茅台从 50% 涨到 55%，均值 > 50%，贡献 > 5.0
+    assert by_symbol["600519"].contribution_pct is not None
+    assert by_symbol["600519"].contribution_pct > 5.0
+    assert by_symbol["000858"].contribution_pct is not None
+    assert by_symbol["000858"].contribution_pct < -4.0
+    assert by_symbol["600000"].partial is True
+
+
+def test_build_attribution_short_window_empty() -> None:
+    assert _build_attribution([_H("600519", "茅台")], qty_series={}, closes={}, common=[]) == []

--- a/tests/services/test_research_persistence.py
+++ b/tests/services/test_research_persistence.py
@@ -1,0 +1,98 @@
+"""Portfolio summary / research persistence — 下沉服务的单元测试。"""
+
+from datetime import date
+
+from stockresearch.core.schemas import ResearchReportOut
+from stockresearch.db.models import Holding
+from stockresearch.services.portfolio_summary import build_portfolio_brief
+from stockresearch.services.research_persistence import (
+    register_cached_report,
+    register_report_verifications,
+)
+
+
+def _holding(symbol: str, name: str, cost: float, qty: int, sector: str = "科技") -> Holding:
+    return Holding(
+        user_id=1,
+        symbol=symbol,
+        name=name,
+        cost_price=cost,
+        quantity=qty,
+        sector=sector,
+        buy_date=date(2024, 5, 1),
+    )
+
+
+def _report(symbol: str = "600519") -> ResearchReportOut:
+    return ResearchReportOut(
+        symbol=symbol,
+        name="贵州茅台",
+        dimensions={},
+        composite_score=6.5,
+        composite_confidence="medium",  # type: ignore[arg-type]
+        bias="bullish",  # type: ignore[arg-type]
+        summary="综合四维看，短期偏强。",
+        disclaimer="以上内容由 AI 生成，仅供参考，不构成投资建议。",
+    )
+
+
+def test_build_portfolio_brief_empty() -> None:
+    brief = build_portfolio_brief([])
+    assert brief["count"] == 0
+    assert brief["total_cost"] == 0.0
+    assert brief["holdings"] == []
+
+
+def test_build_portfolio_brief_aggregates() -> None:
+    brief = build_portfolio_brief(
+        [
+            _holding("600519", "贵州茅台", 1800.0, 100, sector="白酒"),
+            _holding("300750", "宁德时代", 200.0, 500, sector="新能源"),
+            _holding("000858", "五粮液", 150.0, 200, sector="白酒"),
+        ]
+    )
+    assert brief["count"] == 3
+    assert brief["total_cost"] == 1800.0 * 100 + 200.0 * 500 + 150.0 * 200
+    assert brief["total_quantity"] == 800
+    assert brief["sectors"][0] == {"name": "白酒", "count": 2}
+    assert brief["holdings"][0]["buy_date"] == "2024-05-01"
+
+
+def test_register_report_verifications_idempotent(db_session) -> None:
+    from stockresearch.db.models import Prediction, ResearchReport
+
+    report = _report()
+    row = ResearchReport(user_id=1, symbol=report.symbol, name=report.name, report_json={})
+    db_session.add(row)
+    db_session.commit()
+
+    register_report_verifications(db_session, 1, report, report_id=row.id)
+    register_report_verifications(db_session, 1, report, report_id=row.id)
+    preds = db_session.query(Prediction).filter_by(report_id=row.id).all()
+    assert len(preds) == 1  # 幂等：同一报告只登记一次
+
+
+def test_register_cached_report_reuses_latest_row(db_session) -> None:
+    from stockresearch.db.models import Prediction, ResearchReport
+
+    report = _report()
+    row = ResearchReport(user_id=1, symbol=report.symbol, name=report.name, report_json={})
+    db_session.add(row)
+    db_session.commit()
+
+    report_id = register_cached_report(db_session, 1, report)
+    assert report_id == row.id  # 复用已有报告行，不新建
+    assert db_session.query(ResearchReport).count() == 1
+    preds = db_session.query(Prediction).filter_by(report_id=row.id).all()
+    assert len(preds) == 1
+
+
+def test_register_cached_report_creates_row_when_none(db_session) -> None:
+    from stockresearch.db.models import Prediction, ResearchReport
+
+    report = _report()
+    report_id = register_cached_report(db_session, 1, report)
+    assert report_id is not None
+    assert db_session.query(ResearchReport).count() == 1
+    preds = db_session.query(Prediction).filter_by(report_id=report_id).all()
+    assert len(preds) == 1

--- a/tests/services/test_screener.py
+++ b/tests/services/test_screener.py
@@ -1,0 +1,56 @@
+"""Factor screener — 纯函数/服务单元测试（条件匹配与缺数跳过）。"""
+
+from stockresearch.core.schemas import NumericFactorOut, ScreenCondition
+from stockresearch.services.screener import _factor_value, _passes
+
+
+def _f(key: str, value: float | None = 5.0, percentile: float | None = None) -> NumericFactorOut:
+    return NumericFactorOut(key=key, label=key, value=value, percentile=percentile, unit="%")
+
+
+def test_factor_value_returns_float() -> None:
+    assert _factor_value({"momentum_20d": _f("momentum_20d", 5.0)}, "momentum_20d") == 5.0
+    assert _factor_value({"momentum_20d": _f("momentum_20d", None)}, "momentum_20d") is None
+    assert _factor_value({}, "momentum_20d") is None
+
+
+def test_factor_value_pe_percentile_uses_percentile_field() -> None:
+    # value 为空但 percentile 存在（0.42）→ 42.0
+    assert (
+        _factor_value(
+            {"pe_percentile": _f("pe_percentile", None, percentile=0.42)}, "pe_percentile"
+        )
+        == 42.0
+    )
+    # percentile > 1 时直接用原值
+    assert (
+        _factor_value(
+            {"pe_percentile": _f("pe_percentile", None, percentile=42.0)}, "pe_percentile"
+        )
+        == 42.0
+    )
+
+
+def test_passes_all_operators() -> None:
+    factors = {"momentum_20d": _f("momentum_20d", 5.0)}
+    assert _passes(factors, [ScreenCondition(key="momentum_20d", op=">", value=0)])
+    assert _passes(factors, [ScreenCondition(key="momentum_20d", op=">=", value=5.0)])
+    assert _passes(factors, [ScreenCondition(key="momentum_20d", op="<", value=10)])
+    assert _passes(factors, [ScreenCondition(key="momentum_20d", op="<=", value=5.0)])
+    assert not _passes(factors, [ScreenCondition(key="momentum_20d", op=">", value=5.0)])
+    assert not _passes(factors, [ScreenCondition(key="momentum_20d", op="<", value=5.0)])
+
+
+def test_passes_missing_factor_fails() -> None:
+    factors = {"momentum_20d": _f("momentum_20d", None)}
+    assert not _passes(factors, [ScreenCondition(key="momentum_20d", op=">", value=0)])
+
+
+def test_passes_all_conditions_required() -> None:
+    factors = {"momentum_20d": _f("momentum_20d", 5.0), "pe_percentile": _f("pe_percentile", 20.0)}
+    both = [
+        ScreenCondition(key="momentum_20d", op=">", value=0),
+        ScreenCondition(key="pe_percentile", op="<", value=30),
+    ]
+    assert _passes(factors, both)
+    assert not _passes(factors, [*both, ScreenCondition(key="volatility_20d", op=">", value=0)])

--- a/tests/services/test_trade_ledger.py
+++ b/tests/services/test_trade_ledger.py
@@ -1,0 +1,100 @@
+"""下沉后的交易台账服务 — 单元测试（upsert/sell/record 无需 HTTP）。"""
+
+from datetime import date
+
+import pytest
+
+from stockresearch.core.exceptions import ValidationError
+from stockresearch.db.models import Holding, Trade
+from stockresearch.services.trade_ledger import (
+    record_trade,
+    sell_holding,
+    upsert_holding,
+)
+
+
+def test_upsert_holding_creates_new(db_session) -> None:
+    h = upsert_holding(
+        db_session, user_id=1, symbol="600519", name="贵州茅台", cost_price=1800.0, quantity=100
+    )
+    assert h.id is not None
+    assert h.quantity == 100
+    row = db_session.query(Holding).filter_by(user_id=1, symbol="600519").one()
+    assert float(row.cost_price) == 1800.0
+
+
+def test_upsert_holding_averages_cost_on_add(db_session) -> None:
+    upsert_holding(
+        db_session, user_id=1, symbol="600519", name="贵州茅台", cost_price=1800.0, quantity=100
+    )
+    h2 = upsert_holding(
+        db_session, user_id=1, symbol="600519", name="贵州茅台", cost_price=2000.0, quantity=100
+    )
+    assert h2.quantity == 200
+    # 加权平均成本 = (1800*100 + 2000*100) / 200 = 1900
+    assert float(h2.cost_price) == pytest.approx(1900.0)
+
+
+def test_upsert_holding_updates_sector_and_buy_date(db_session) -> None:
+    h = upsert_holding(
+        db_session,
+        user_id=1,
+        symbol="600519",
+        name="贵州茅台",
+        cost_price=1800.0,
+        quantity=100,
+        sector="白酒",
+        buy_date=date(2024, 5, 1),
+    )
+    assert h.sector == "白酒"
+    assert h.buy_date == date(2024, 5, 1)
+
+
+def test_sell_holding_reduces_quantity(db_session) -> None:
+    upsert_holding(
+        db_session, user_id=1, symbol="600519", name="贵州茅台", cost_price=1800.0, quantity=300
+    )
+    sell_holding(db_session, user_id=1, symbol="600519", quantity=100)
+    h = db_session.query(Holding).filter_by(user_id=1, symbol="600519").one()
+    assert h.quantity == 200
+
+
+def test_sell_holding_deletes_when_zero(db_session) -> None:
+    upsert_holding(
+        db_session, user_id=1, symbol="600519", name="贵州茅台", cost_price=1800.0, quantity=100
+    )
+    sell_holding(db_session, user_id=1, symbol="600519", quantity=100)
+    assert db_session.query(Holding).filter_by(user_id=1, symbol="600519").first() is None
+
+
+def test_sell_holding_over_quantity_raises(db_session) -> None:
+    upsert_holding(
+        db_session, user_id=1, symbol="600519", name="贵州茅台", cost_price=1800.0, quantity=100
+    )
+    with pytest.raises(ValidationError, match="超出持仓"):
+        sell_holding(db_session, user_id=1, symbol="600519", quantity=200)
+
+
+def test_record_trade_attaches_latest_report(db_session) -> None:
+    from stockresearch.db.models import ResearchReport
+
+    upsert_holding(
+        db_session, user_id=1, symbol="600519", name="贵州茅台", cost_price=1800.0, quantity=100
+    )
+    report = ResearchReport(user_id=1, symbol="600519", name="贵州茅台", report_json={})
+    db_session.add(report)
+    db_session.commit()
+
+    t = record_trade(
+        db_session,
+        user_id=1,
+        symbol="600519",
+        name="贵州茅台",
+        side="buy",
+        price=1800.0,
+        quantity=100,
+        note="  决策备注  ",
+    )
+    assert t.report_id == report.id
+    assert t.note == "决策备注"
+    assert db_session.query(Trade).count() == 1


### PR DESCRIPTION
## 变更（体检报告剩余大项）

### 1. 风控双实现收敛
- `_load_quotes_with_placeholders`（批量行情 + 缺失占位防 zip 崩）抽到 engine.py
- `portfolio_summary_from_alerts`（无持仓/无告警/有告警三态文案）抽到 engine.py
- stream.py 删除 ~40 行重复实现，与同步路径共享同一规则解析/量化/摘要

### 2. 业务逻辑下沉（脱离 HTTP 层，可复用可测）
- `services/trade_ledger.py` — record_trade / upsert_holding / sell_holding /
  resolve_transaction_symbol_name / resolve_holding（原 portfolio.py 路由内函数）
- `services/research_persistence.py` — persist_report / register_report_verifications /
  register_cached_report / stamp_report_id / attach_report_ids_to_cards /
  extract_reports_from_cards（原 research.py 路由内函数）
- `services/risk_persistence.py` — persist_alerts（原 risk.py 路由内函数）
- **chat.py 跨路由 import 改指 services** —— 消除路由间耦合（此前 chat 从 research
  路由模块 import 业务函数，业务逻辑被锁死在 HTTP 层）

### 3. 测试补缺 +30（753 → 原 723）
- market_regime（7）：趋势/震荡/数据不足/零起点/标签/收益率
- portfolio_performance（6）：已实现盈亏汇总/台账回放/近似标记/归因贡献
- screener（5）：条件运算符/缺数跳过/PE 分位取 percentile 字段
- trade_ledger（7）：成本加权平均/卖出校验/零仓删除/研报挂接/备注清理
- research_persistence（5）：登记幂等/缓存复用最近行/无行时新建

### 验证
- 后端 753 passed、前端 112 passed、build/lint/mypy/ruff 全绿
- 契约测试同步（persist_report 断言改指 services.research_persistence）