### PR TITLE
feat: 工具调用 schema 校验层（Pydantic-AI 式零依赖）

### DIFF
--- a/src/stockresearch/agents/orchestrator/plan_execute.py
+++ b/src/stockresearch/agents/orchestrator/plan_execute.py
@@ -8,11 +8,24 @@ import json
 import logging
 from typing import Any
 
-from stockresearch.agents.orchestrator.tools_registry import FINANCE_TOOLS, format_tools_for_prompt
+from stockresearch.agents.orchestrator.tool_schema import (
+    LEGACY_SKILL_ALIASES,
+    ToolCallValidator,
+)
+from stockresearch.agents.orchestrator.tools_registry import (
+    FINANCE_TOOLS,
+    ORCHESTRATOR_TOOLS,
+    format_tools_for_prompt,
+)
 from stockresearch.i18n.status_events import status_event
 from stockresearch.utils.llm import LLMClient
 
 logger = logging.getLogger(__name__)
+
+_VALIDATOR = ToolCallValidator(
+    frozenset(tool.name for tool in ORCHESTRATOR_TOOLS),
+    LEGACY_SKILL_ALIASES,
+)
 
 _PLAN_GENERAL_SYSTEM = """你是「StockResearch」的研究规划 Agent。用户提出了一个与股票投资无直接关系的复杂问题，请制定分析计划。
 
@@ -434,8 +447,11 @@ class PlanExecuteAgent:
 
         # If tool_executor is available and tool is known, use it directly
         if self._tool_executor and tool_name != "auto":
+            normalized, error = _VALIDATOR.validate({"tool": tool_name, "args": tool_args})
+            if error is not None or normalized is None:
+                return f"[工具调用格式错误] {error}"
             try:
-                return await self._tool_executor(tool_name, tool_args)
+                return await self._tool_executor(normalized["tool"], normalized["args"])
             except Exception as exc:
                 logger.warning("Tool %s failed: %s", tool_name, exc)
                 return f"工具 {tool_name} 执行失败: {exc}"
@@ -457,17 +473,21 @@ class PlanExecuteAgent:
         tool_calls = _extract_tool_calls(response)
         if tool_calls and self._tool_executor:
             results = []
-            for tc in tool_calls:
-                tc_name = tc["tool"]
+            for raw_tc in tool_calls:
+                normalized, error = _VALIDATOR.validate(raw_tc)
+                if error is not None or normalized is None:
+                    results.append(f"[工具调用格式错误] {error}")
+                    continue
+                tc_name = normalized["tool"]
                 if not self._finance_tools and tc_name in FINANCE_TOOLS:
                     results.append(f"工具 {tc_name} 已禁用：当前问题与股票投资无关。")
                     continue
                 try:
-                    r = await self._tool_executor(tc_name, tc.get("args", {}))
+                    r = await self._tool_executor(tc_name, normalized.get("args", {}))
                     results.append(r)
                 except Exception as exc:
                     logger.warning("tool %s failed: %s", tc_name, exc, exc_info=True)
-                    results.append(f"工具 {tc['tool']} 失败: {exc}")
+                    results.append(f"工具 {tc_name} 失败: {exc}")
             return "\n".join(results)
 
         return response.strip()

--- a/src/stockresearch/agents/orchestrator/react_agent.py
+++ b/src/stockresearch/agents/orchestrator/react_agent.py
@@ -12,8 +12,13 @@ from sqlalchemy.orm import Session
 
 from stockresearch.agents.news.agent import get_news_for_user
 from stockresearch.agents.orchestrator.skills import SKILL_IDS, SkillRunner
+from stockresearch.agents.orchestrator.tool_schema import (
+    LEGACY_SKILL_ALIASES,
+    ToolCallValidator,
+)
 from stockresearch.agents.orchestrator.tools_registry import (
     FINANCE_TOOLS,
+    ORCHESTRATOR_TOOLS,
     format_tools_for_prompt,
     research_skills_prompt_note,
 )
@@ -101,10 +106,10 @@ _RESEARCH_SKILL_BLOCK = frozenset(
 _MAX_ITERATIONS = 8
 _MAX_TOOL_RESULT_CHARS = 2000
 
-_LEGACY_SKILL_ALIASES: dict[str, str] = {
-    "get_stock_research": "skill_stock_research",
-    "debate_stock": "skill_bull_bear_debate",
-}
+_VALIDATOR = ToolCallValidator(
+    frozenset(tool.name for tool in ORCHESTRATOR_TOOLS),
+    LEGACY_SKILL_ALIASES,
+)
 
 
 def _truncate_tool_result(result: str) -> str:
@@ -280,7 +285,21 @@ class OrchestratorAgent:
 
             messages.append({"role": "assistant", "content": response})
 
+            validated: list[dict[str, Any]] = []
             for tc in tool_calls:
+                normalized, error = _VALIDATOR.validate(tc)
+                if error is not None or normalized is None:
+                    messages.append(
+                        {
+                            "role": "user",
+                            "content": f"[工具调用格式错误]\n{error}\n请修正后重试。",
+                        }
+                    )
+                    logger.info(self._log_ctx("ReAct iter %d: rejected tool call: %s"), i, error)
+                    continue
+                validated.append(normalized)
+
+            for tc in validated:
                 tool_name = tc.get("tool", "")
                 tool_args = tc.get("args", {})
                 # Progress hint based on tool
@@ -293,7 +312,7 @@ class OrchestratorAgent:
                     "get_news": ("status.react.news", {}),
                     "reply": ("status.react.reply", {}),
                 }
-                if tool_name in SKILL_IDS or tool_name in _LEGACY_SKILL_ALIASES:
+                if tool_name in SKILL_IDS or tool_name in LEGACY_SKILL_ALIASES:
                     key, params = ("status.react.skill", {"tool": tool_name})
                 else:
                     key, params = tool_status_keys.get(
@@ -330,7 +349,7 @@ class OrchestratorAgent:
     async def _execute_tool(self, name: str, args: dict[str, Any]) -> str:
         if not self._finance_tools and name in FINANCE_TOOLS:
             return f"工具 {name} 已禁用：当前问题与股票投资无关，请直接基于知识回答。"
-        skill_name = _LEGACY_SKILL_ALIASES.get(name, name)
+        skill_name = LEGACY_SKILL_ALIASES.get(name, name)
         if skill_name in PORTFOLIO_TOOL_NAMES and not self._portfolio_context:
             return f"工具 {name} 不可用：当前问题未涉及持仓组合，请勿调用持仓相关工具。"
         if self._news_explain_only and skill_name in _RESEARCH_SKILL_BLOCK:

--- a/src/stockresearch/agents/orchestrator/tool_schema.py
+++ b/src/stockresearch/agents/orchestrator/tool_schema.py
@@ -1,0 +1,81 @@
+"""Tool-call schema validation — zero-dependency reliability layer.
+
+Orchestrator ReAct loops parse free-form JSON tool calls out of LLM text.
+Before execution each call is validated and normalized here (the cheap,
+framework-free version of what Pydantic-AI provides through typed tool
+schemas):
+
+- the tool name must resolve to a known tool/skill (legacy aliases normalize)
+- args must be a JSON object
+- numeric scalars coerce to str (symbols are digits); bools stay bool
+
+Failed calls return a corrective Chinese message so the loop can retry
+with the error injected into context.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field, TypeAdapter, ValidationError
+
+from stockresearch.agents.orchestrator.skills import SKILL_IDS
+
+LEGACY_SKILL_ALIASES: dict[str, str] = {
+    "get_stock_research": "skill_stock_research",
+    "debate_stock": "skill_bull_bear_debate",
+}
+
+
+class _ToolCall(BaseModel):
+    tool: str = Field(min_length=1)
+    args: dict[str, Any] = Field(default_factory=dict)
+
+
+def _coerce_scalars(args: dict[str, Any]) -> dict[str, Any]:
+    """int/float -> str (symbols are digits), bool kept as-is (with_debate etc.)."""
+    return {
+        key: (
+            value
+            if isinstance(value, bool)
+            else str(value)
+            if isinstance(value, (int, float))
+            else value
+        )
+        for key, value in args.items()
+    }
+
+
+class ToolCallValidator:
+    """Validate and normalize a single LLM-produced tool call."""
+
+    def __init__(
+        self,
+        known_tools: set[str] | frozenset[str],
+        legacy_aliases: dict[str, str] | None = None,
+        *,
+        error_list_limit: int = 16,
+    ) -> None:
+        self._known = frozenset(known_tools) | frozenset(SKILL_IDS)
+        self._aliases = dict(legacy_aliases or {})
+        self._adapter = TypeAdapter(_ToolCall)
+        self._error_list_limit = error_list_limit
+
+    def validate(self, data: object) -> tuple[dict[str, Any] | None, str | None]:
+        """Return (normalized_call, error); exactly one of the two is None."""
+        try:
+            call = self._adapter.validate_python(data)
+        except ValidationError as exc:
+            return None, self._format_error(exc)
+        name = self._aliases.get(call.tool, call.tool)
+        if name not in self._known:
+            available = ", ".join(sorted(self._known)[: self._error_list_limit])
+            return None, f"工具 {call.tool} 不存在，可用工具: {available}"
+        return {"tool": name, "args": _coerce_scalars(call.args)}, None
+
+    def _format_error(self, exc: ValidationError) -> str:
+        parts: list[str] = []
+        for error in exc.errors():
+            loc = ".".join(str(part) for part in error["loc"]) or "调用"
+            parts.append(f"{loc}: {error['msg']}")
+        return "工具调用格式错误: " + "; ".join(parts)

--- a/tests/agents/test_tool_schema.py
+++ b/tests/agents/test_tool_schema.py
@@ -1,0 +1,132 @@
+"""Tool-call schema validation tests (framework-free Pydantic-AI-style layer)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from sqlalchemy.orm import Session
+
+from stockresearch.agents.orchestrator.plan_execute import PlanExecuteAgent
+from stockresearch.agents.orchestrator.react_agent import _VALIDATOR, OrchestratorAgent
+from stockresearch.db.models import User
+
+
+def test_valid_call_passthrough() -> None:
+    norm, error = _VALIDATOR.validate({"tool": "get_news", "args": {"symbol": "600519"}})
+    assert error is None
+    assert norm == {"tool": "get_news", "args": {"symbol": "600519"}}
+
+
+def test_args_optional() -> None:
+    norm, error = _VALIDATOR.validate({"tool": "reply"})
+    assert error is None
+    assert norm == {"tool": "reply", "args": {}}
+
+
+def test_unknown_tool_rejected() -> None:
+    _, error = _VALIDATOR.validate({"tool": "get_stock_price", "args": {}})
+    assert error is not None
+    assert "不存在" in error
+    assert "get_stock_quote" in error
+
+
+def test_args_must_be_object() -> None:
+    _, error = _VALIDATOR.validate({"tool": "get_news", "args": "600519"})
+    assert error is not None
+    assert "格式错误" in error
+
+
+def test_non_dict_input_rejected() -> None:
+    _, error = _VALIDATOR.validate("not-a-dict")
+    assert error is not None
+
+
+def test_numeric_symbol_coerced_to_str() -> None:
+    norm, error = _VALIDATOR.validate({"tool": "get_stock_quote", "args": {"symbol": 600519}})
+    assert error is None
+    assert norm == {"tool": "get_stock_quote", "args": {"symbol": "600519"}}
+
+
+def test_bool_arg_preserved() -> None:
+    norm, error = _VALIDATOR.validate(
+        {"tool": "skill_stock_research", "args": {"with_debate": False, "symbol": 1}}
+    )
+    assert error is None
+    assert norm is not None
+    assert norm["args"]["with_debate"] is False
+    assert norm["args"]["symbol"] == "1"
+
+
+def test_legacy_alias_normalized() -> None:
+    norm, error = _VALIDATOR.validate({"tool": "get_stock_research", "args": {"symbol": "600519"}})
+    assert error is None
+    assert norm == {"tool": "skill_stock_research", "args": {"symbol": "600519"}}
+
+
+class SequencedLLM:
+    """Replies with preset responses, records every messages payload."""
+
+    def __init__(self, *responses: str) -> None:
+        self._responses = list(responses)
+        self.calls: list[list[dict[str, str]]] = []
+
+    async def complete_messages(self, messages: list[dict[str, str]]) -> str:
+        self.calls.append(list(messages))
+        if self._responses:
+            return self._responses.pop(0)
+        return "抱歉，我暂时无法回答，请稍后再试。"
+
+
+@pytest.mark.asyncio
+async def test_rejected_call_injected_back_and_retry(db_session: Session) -> None:
+    user = User(username="tool-schema-retry", password_hash="")
+    db_session.add(user)
+    db_session.commit()
+
+    llm = SequencedLLM(
+        '```tool\n{"tool": "get_stock_price", "args": {"symbol": "600519"}}\n```',
+        '```tool\n{"tool": "reply", "args": {"message": "完成"}}\n```',
+    )
+    agent = OrchestratorAgent(db_session, llm, user_id=user.id)  # type: ignore[arg-type]
+    reply, _ = await agent.run("测试")
+    assert reply == "完成"
+    assert len(llm.calls) == 2
+    assert "不存在" in llm.calls[1][-1]["content"]
+
+
+@pytest.mark.asyncio
+async def test_mixed_calls_execute_valid_only(db_session: Session) -> None:
+    user = User(username="tool-schema-mixed", password_hash="")
+    db_session.add(user)
+    db_session.commit()
+
+    llm = SequencedLLM(
+        '```tool\n{"tool": "get_stock_price", "args": {}}\n```\n'
+        '```tool\n{"tool": "reply", "args": {"message": "完成"}}\n```'
+    )
+    agent = OrchestratorAgent(db_session, llm, user_id=user.id)  # type: ignore[arg-type]
+    reply, _ = await agent.run("测试")
+    assert reply == "完成"
+    assert len(llm.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_plan_step_rejects_invalid_tool_call() -> None:
+    executed: list[tuple[str, dict[str, Any]]] = []
+
+    class PlanLLM:
+        async def complete(self, system: str, user: str) -> str:
+            return '```tool\n{"tool": "not_a_tool", "args": {}}\n```'
+
+    async def executor(name: str, args: dict[str, Any]) -> str:
+        executed.append((name, args))
+        return "ok"
+
+    agent = PlanExecuteAgent(PlanLLM(), tool_executor=executor)  # type: ignore[arg-type]
+    result = await agent._execute_step(
+        "测试",
+        {"id": 1, "description": "步骤", "tool": "auto", "args": {}},
+    )
+    assert "格式错误" in result
+    assert executed == []


### PR DESCRIPTION
## 背景

ReAct/Plan-Execute 循环解析 LLM 自由 JSON 工具调用后直接执行，格式错误（未知工具名、args 非对象、symbol 传数字）只能靠执行期异常兜底。

## 改动

- **新增 `tool_schema.py`**：`ToolCallValidator` — 用 `pydantic.TypeAdapter` 强校验（tool 名枚举 + args 必须为 object），int/float 标量自动转 str（symbol 场景），bool 保留（with_debate 语义），legacy 别名归一化
- **react_agent.py**：ReAct 循环执行前校验，非法调用以 `[工具调用格式错误]` 回灌消息历史让 LLM 修正重试（不执行、不终结循环）
- **plan_execute.py**：步骤声明 + LLM 自由调用两处路径接入同一校验器，非法调用返回错误说明而非执行

## 测试

新增 `tests/agents/test_tool_schema.py`（11 个用例）：合法/未知工具/args 非 object/非 dict 输入/数字转字符串/bool 保留/别名归一化/错误回灌重试/混合调用只执行合法项/plan 步骤拒绝。全套 764 passed，mypy/ruff 通过。